### PR TITLE
cmake: add installation target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/${BIN_DIRECTORY})
 add_executable(basisu ${BASISU_SRC_LIST})
 target_link_libraries(basisu m pthread)
 
+install(TARGETS basisu DESTINATION bin)
+
 if (CMAKE_BUILD_TYPE STREQUAL Release)
     if (APPLE)
 	    add_custom_command(TARGET basisu POST_BUILD COMMAND strip -X -x ${CMAKE_SOURCE_DIR}/${BIN_DIRECTORY}/basisu)


### PR DESCRIPTION
This allows to run `$BUILDTOOL install` to install `basisu` on your system, where `$BUILDTOOL` might be `ninja` or `make` for instance.