### PR TITLE
Fix webgl CMakeLists.txt setup

### DIFF
--- a/webgl/transcoder/CMakeLists.txt
+++ b/webgl/transcoder/CMakeLists.txt
@@ -10,10 +10,12 @@ if (EMSCRIPTEN)
     basis_wrappers.cpp
   )
 
+  target_compile_definitions(basis_transcoder.js PRIVATE NDEBUG BASISD_SUPPORT_BC7=0)
+  target_compile_options(basis_transcoder.js PRIVATE -O3)
   target_include_directories(basis_transcoder.js PRIVATE ../../transcoder)
 
   set_target_properties(basis_transcoder.js PROPERTIES
       OUTPUT_NAME "basis_transcoder"
       SUFFIX ".js"
-      LINK_FLAGS "--bind -s ALLOW_MEMORY_GROWTH=1 -O3 -s ASSERTIONS=0 -s MALLOC=emmalloc -DNDEBUG -DBASISD_SUPPORT_BC7=0")
+      LINK_FLAGS "--bind -s ALLOW_MEMORY_GROWTH=1 -O3 -s ASSERTIONS=0 -s MALLOC=emmalloc")
 endif()


### PR DESCRIPTION
It looks like #7 didn't update CMakeLists.txt properly - defines
specified with -D have to be added as compile definitions.

Additionally, -O3 must be specified redundantly as a compile option and
as a link option - compile option makes .wasm bits small & fast, and
link option enables JS minifier.

After this fix CMake build results in minimal js/wasm files as well.