### PR TITLE
Properly disable copy ctor and assignment operator

### DIFF
--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -69,7 +69,7 @@
 
 #define BASISU_NOTE_UNUSED(x) (void)(x)
 #define BASISU_ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
-#define BASISU_NO_EQUALS_OR_COPY_CONSTRUCT(x) x(x &); x& operator= (const x&);
+#define BASISU_NO_EQUALS_OR_COPY_CONSTRUCT(x) x(const x &) = delete; x& operator= (const x &) = delete;
 #define BASISU_ASSUME(x) static_assert(x, #x);
 #define BASISU_OFFSETOF(s, m) (uint32_t)(intptr_t)(&((s *)(0))->m)
 #define BASISU_STRINGIZE(x) #x


### PR DESCRIPTION
The existing `BASISU_NO_EQUALS_OR_COPY_CONSTRUCT` forward declares the copy ctor and assignment operator, but doesn't actually prevent someone from then adding the implementation.  Additionally, the copy ctor is declared as taking a non-const reference, so someone could easily declare `X(const X&)`.

This PR corrects the parameter type on the copy constructor and explicitly declares both methods as deleted, so they _cannot_ be implemented.  
