### PR TITLE
Avoid iterator debug level mismatches for linking as library

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -30,12 +30,15 @@ Rename this file to lodepng.cpp to use it for C++, or to lodepng.c to use it for
 
 #ifdef _MSC_VER
 #pragma warning (disable : 4201)
+
+#ifndef BASISU_NO_ITERATOR_DEBUG_LEVEL
 #if defined(_DEBUG) || defined(DEBUG)
 #define _ITERATOR_DEBUG_LEVEL 1
 #define _SECURE_SCL 1
 #else
 #define _SECURE_SCL 0
 #define _ITERATOR_DEBUG_LEVEL 0
+#endif
 #endif
 #endif
 

--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -19,6 +19,7 @@
 #pragma warning (disable : 4201)
 #pragma warning (disable : 4127) // warning C4127: conditional expression is constant
 #pragma warning (disable : 4530) // C++ exception handler used, but unwind semantics are not enabled.
+#ifndef BASISU_NO_ITERATOR_DEBUG_LEVEL
 //#define _HAS_ITERATOR_DEBUGGING 0
 #if defined(_DEBUG) || defined(DEBUG)
 #define _ITERATOR_DEBUG_LEVEL 1
@@ -26,6 +27,7 @@
 #else
 #define _SECURE_SCL 0
 #define _ITERATOR_DEBUG_LEVEL 0
+#endif
 #endif
 #ifndef NOMINMAX
 	#define NOMINMAX


### PR DESCRIPTION
Hi @richgel999 !

Since MSVC does not allow linking of libaries with different iterator debug levels, this PR adds a `BASISU_NO_ITERATOR_DEBUG_LEVEL` symbol to avoid setting of `_ITERATOR_DEBUG_LEVEL` from default `2` to `1` on debug configurations. This would help the integration into [Magnum](https://github.com/mosra/magnum) a lot, as basis can then be linked to code that uses the default debug levels.

Thanks in advance!

Cheers, Jonathan.
