### PR TITLE
Add -opencl option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
 set(CMAKE_CXX_FLAGS -std=c++11)
-set(GCC_COMPILE_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -fPIC -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wno-unused-local-typedefs -Wno-unused-value -Wno-unused-parameter -Wno-unused-variable -Wno-reorder")
+set(GCC_COMPILE_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden -fPIC -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wno-unused-local-typedefs -Wno-unused-value -Wno-unused-parameter -Wno-unused-variable -Wno-reorder -Wno-maybe-uninitialized -Wno-ignored-attributes")
 
 if (NOT BUILD_X64)
 	set(GCC_COMPILE_FLAGS "${GCC_COMPILE_FLAGS} -m32")
@@ -72,8 +72,10 @@ endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/${BIN_DIRECTORY})
 
+add_subdirectory(opencl)
 add_executable(basisu ${BASISU_SRC_LIST})
-target_link_libraries(basisu m pthread)
+target_link_libraries(basisu m pthread basisu_opencl)
+target_include_directories(basisu PRIVATE .)
 
 install(TARGETS basisu DESTINATION bin)
 

--- a/basisu_comp.cpp
+++ b/basisu_comp.cpp
@@ -798,6 +798,7 @@ namespace basisu
 		p.m_compression_level = m_params.m_compression_level;
 		p.m_tex_type = m_params.m_tex_type;
 		p.m_multithreaded = m_params.m_multithreading;
+		p.m_opencl = m_params.m_opencl;
 		p.m_disable_hierarchical_endpoint_codebooks = m_params.m_disable_hierarchical_endpoint_codebooks;
 		p.m_pJob_pool = m_params.m_pJob_pool;
 

--- a/basisu_comp.h
+++ b/basisu_comp.h
@@ -219,6 +219,7 @@ namespace basisu
 			m_check_for_alpha.clear();
 			m_force_alpha.clear();
 			m_multithreading.clear();
+			m_opencl.clear();
 			m_seperate_rg_to_color_alpha.clear();
 			m_hybrid_sel_cb_quality_thresh.clear();
 			m_global_pal_bits.clear();
@@ -309,6 +310,7 @@ namespace basisu
 		// Always put alpha slices in the output basis file, even when the input doesn't have alpha
 		bool_param<false> m_force_alpha; 
 		bool_param<true> m_multithreading;
+		bool_param<false> m_opencl;
 		
 		// Split the R channel to RGB and the G channel to alpha, then write a basis file with alpha channels
 		bool_param<false> m_seperate_rg_to_color_alpha;

--- a/basisu_etc.cpp
+++ b/basisu_etc.cpp
@@ -19,9 +19,7 @@
 
 namespace basisu
 {
-	const uint32_t BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE = 165;
-
-	static const struct { uint8_t m_v[4]; } g_cluster_fit_order_tab[BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE] =
+	const cluster_fit_vec g_cluster_fit_order_tab[BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE] =
 	{
 		{ { 0, 0, 0, 8 } },{ { 0, 5, 2, 1 } },{ { 0, 6, 1, 1 } },{ { 0, 7, 0, 1 } },{ { 0, 7, 1, 0 } },
 		{ { 0, 0, 8, 0 } },{ { 0, 0, 3, 5 } },{ { 0, 1, 7, 0 } },{ { 0, 0, 4, 4 } },{ { 0, 0, 2, 6 } },

--- a/basisu_etc.h
+++ b/basisu_etc.h
@@ -72,12 +72,17 @@ namespace basisu
 		cETC1ColorDeltaMin = -4,
 		cETC1ColorDeltaMax = 3,
 
+		BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE = 165,
 		// Delta3:
 		// 0   1   2   3   4   5   6   7
 		// 000 001 010 011 100 101 110 111
 		// 0   1   2   3   -4  -3  -2  -1
 	};
-	
+
+	struct cluster_fit_vec {
+		uint8_t m_v[4];
+	};
+	extern const cluster_fit_vec g_cluster_fit_order_tab[BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE];
 	extern const int g_etc1_inten_tables[cETC1IntenModifierValues][cETC1SelectorValues];
 	extern const uint8_t g_etc1_to_selector_index[cETC1SelectorValues];
 	extern const uint8_t g_selector_index_to_etc1[cETC1SelectorValues];

--- a/basisu_frontend.cpp
+++ b/basisu_frontend.cpp
@@ -19,6 +19,7 @@
 //
 #include "transcoder/basisu.h"
 #include "basisu_frontend.h"
+#include "opencl/oclhost.h"
 #include <unordered_set>
 #include <unordered_map>
 
@@ -174,11 +175,23 @@ namespace basisu
 	bool basisu_frontend::compress()
 	{
 		debug_printf("basisu_frontend::compress\n");
+		oclhost host;
+		if (m_params.m_opencl) {
+			if (!host.init(m_params, false /*use_color4*/)) {
+				return false;
+			}
+			if (!host.runFrontend(m_source_blocks)) {
+				return false;
+			}
+		}
 
 		m_total_blocks = m_params.m_num_source_blocks;
 		m_total_pixels = m_total_blocks * cPixelBlockTotalPixels;
 
 		init_etc1_images();
+		if (m_params.m_opencl) {
+			host.check_results(m_etc1_blocks_etc1s);
+		}
 
 		init_endpoint_training_vectors();
 

--- a/basisu_frontend.h
+++ b/basisu_frontend.h
@@ -81,6 +81,7 @@ namespace basisu
 				m_validate(false),
 				m_tex_type(basist::cBASISTexType2D),
 				m_multithreaded(false),
+				m_opencl(false),
 				m_disable_hierarchical_endpoint_codebooks(false),
 				m_pJob_pool(nullptr)
 			{
@@ -100,6 +101,7 @@ namespace basisu
 			bool m_dump_endpoint_clusterization;
 			bool m_validate;
 			bool m_multithreaded;
+			bool m_opencl;
 			bool m_disable_hierarchical_endpoint_codebooks;
 			
 			const basist::etc1_global_selector_codebook *m_pGlobal_sel_codebook;

--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -84,6 +84,7 @@ static void print_usage()
 		" -force_alpha: Always output alpha basis files, even if no inputs has alpha\n"
 		" -seperate_rg_to_color_alpha: Seperate input R and G channels to RGB and A (for tangent space XY normal maps)\n"
 		" -no_multithreading: Disable multithreading\n"
+		" -opencl: Enable OpenCL (experimental)\n"
 		" -no_ktx: Disable KTX writing when unpacking (faster)\n"
 		" -etc1_only: Only unpack to ETC1, skipping the other texture formats during -unpack\n"
 		" -disable_hierarchical_endpoint_codebooks: Disable hierarchical endpoint codebook usage, slower but higher quality on some compression levels\n"
@@ -349,6 +350,8 @@ public:
 			{
 				m_comp_params.m_multithreading = false;
 			}
+			else if (strcasecmp(pArg, "-opencl") == 0)
+				m_comp_params.m_opencl = true;
 			else if (strcasecmp(pArg, "-mipmap") == 0)
 				m_comp_params.m_mip_gen = true;
 			else if (strcasecmp(pArg, "-no_ktx") == 0)

--- a/opencl/CMakeLists.txt
+++ b/opencl/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.0)
+include(ExternalData)
+
+set(BASISU_OPENCL_SRC_LIST
+	oclhost.cpp
+	ocldevice.cpp
+	oclfrontend.cpp
+	oclprogram.cpp
+	oclhost.h
+	oclhost_internal.h
+	oclfrontend_api.h
+	)
+
+add_library(basisu_opencl ${BASISU_OPENCL_SRC_LIST})
+target_link_libraries(basisu_opencl OpenCL)
+target_include_directories(basisu_opencl PRIVATE ..)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+	message(WARNING "TODO: build frontend.c.i into the binary")
+endif()

--- a/opencl/frontend.c
+++ b/opencl/frontend.c
@@ -1,0 +1,367 @@
+// frontend.c
+// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Define types for oclfrontend_api.h without an #include <OpenCL.h>:
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long uint64_t;
+typedef uint8_t cl_uchar;
+typedef int cl_int;
+typedef uint32_t cl_uint;
+typedef uint64_t cl_ulong;
+typedef float cl_float;
+typedef int4 cl_int4;
+// Now ready to #include "oclfrontend_api.h"
+
+#include "oclfrontend_api.h"
+
+/* The following macros are defined in oclhost.cpp when the kernel is compiled. */
+#if 0
+#define ETC1_QUALITY ETC1_Q_SLOW /*or some similar ETC1_Q_* value*/
+#define ETC1_NO_PERCEPTUAL 1 /*because default is PERCEPTUAL*/
+#define ETC1_NO_CLUSTER_FIT 1 /*because default is CLUSTER_FIT*/
+#define ETC1_FORCE_ETC1S 1
+#define ETC1_USE_COLOR4 1 /*because default is no COLOR4 */
+#endif
+
+#define UINT64_MAX ((uint64_t) -1)
+#define TYPEOF_CONST __constant opencl_const*
+
+uint4 unpackVec4(uint32_t rgba) {
+	return (uint4)(rgba & 0xff, (rgba >> 8) & 0xff, (rgba >> 16) & 0xff, (rgba >> 24) & 0xff);
+}
+
+__constant int* get_inten_table(TYPEOF_CONST THE_C, uint32_t i) {
+	return &THE_C->g_etc1_inten_tables[i][0];
+}
+
+void get_cluster_fit_order_tab(TYPEOF_CONST THE_C, uint32_t i, int out[4]) {
+	uint v = THE_C->g_cluster_fit_order_tab[i];
+	for (int q = 0; q < 4; q++) {
+		out[q] = (int)((v >> (8*q)) & 0xff);
+	}
+}
+
+int4 get_scaled_color(const etc1_solution_coordinates* coords) {
+	int4 c = coords->unscaled_color;
+#ifdef ETC1_USE_COLOR4
+	c |= c << 4;
+#else
+	c = (c >> 2) | (c << 3);
+#endif
+	c.w = 255;
+	return c;
+}
+
+void sort_luma(__global etc1_optimizer* self) {
+	for (int i = 0; i < ETC1_OPTIMIZER_NUM_SRC_PIXELS; i++) {
+		self->sorted_luma_indices[i] = i;
+	}
+
+	int beg[ETC1_OPTIMIZER_NUM_SRC_PIXELS], end[ETC1_OPTIMIZER_NUM_SRC_PIXELS];
+	beg[0] = 0;
+	end[0] = ETC1_OPTIMIZER_NUM_SRC_PIXELS;
+	for (int i = 0; i >= 0; ) {
+		int L = beg[i];
+		int R = end[i]-1;
+		int piv = self->sorted_luma_indices[L];
+		if (L >= R) {
+			i--;
+			continue;
+		}
+		while (L < R) {
+			while (self->luma[self->sorted_luma_indices[R]] >= self->luma[piv] && L<R) R--;
+			if (L<R) self->sorted_luma_indices[L++] = self->sorted_luma_indices[R];
+			while (self->luma[self->sorted_luma_indices[L]] <= self->luma[piv] && L<R) L++;
+			if (L<R) self->sorted_luma_indices[R--] = self->sorted_luma_indices[L];
+		}
+		self->sorted_luma_indices[L] = piv;
+		beg[i+1] = L+1;
+		end[i+1] = end[i];
+		end[i++] = L;
+		if (end[i]-beg[i] > end[i-1]-beg[i-1]) {
+			piv = beg[i]; beg[i] = beg[i-1]; beg[i-1] = piv;
+			piv = end[i]; end[i] = end[i-1]; end[i-1] = piv;
+		}
+	}
+	for (int i = 0; i < ETC1_OPTIMIZER_NUM_SRC_PIXELS; i++) {
+		self->sorted_luma[i] = self->luma[self->sorted_luma_indices[i]];
+	}
+}
+
+__constant double4 rgbWeight = (double4)(.2126f, .715f, .0722f, 0);
+__constant double3 invRgbWeight = (double3)(
+		32.0f*4.0f,
+		32.0f*2.0f*(.5f / (1.0f - .2126f))*(.5f / (1.0f - .2126f)),
+		32.0f*.25f*(.5f / (1.0f - .0722f))*(.5f / (1.0f - .0722f)));
+uint64_t color_distance_rgb(uint3 c0, uint3 c1) {
+#ifdef ETC1_NO_PERCEPTUAL
+	uint3 r = abs_diff(c0, c1);
+	return r.x*r.x + r.y*r.y + r.z*r.z;
+#else
+	// Very small errors crop up when float is used instead of double:
+	// c0 = [ca 97 6c] c1 = [bd 8c 62] err=16566 should be 16565 (offset of +1)
+	double4 c0d = (double4)(convert_double3(c0), 0);
+	c0d -= dot(c0d, rgbWeight);
+	double4 c1d = (double4)(convert_double3(c1), 0);
+	c1d -= dot(c1d, rgbWeight);
+	c1d -= c0d;
+	uint64_t d = convert_ulong_rtz(dot(invRgbWeight, c1d.wxz * c1d.wxz));
+	/* alpha channel is:
+		long da = convert_long_rtz(c0d.w) - convert_long_rtz(c1d.w);
+		d += 128 * da * da;
+	*/
+	return d;
+#endif
+}
+
+uint64_t evaluate_solution_fast(TYPEOF_CONST THE_C, __global etc1_optimizer* self, int3 base_color,
+		etc1_optimizer_solution* trial_solution, cl_uchar selectors[ETC1_OPTIMIZER_NUM_SRC_PIXELS], int inten_table) {
+	__constant int* pinten = get_inten_table(THE_C, inten_table);
+	uint32_t block_inten[4];
+	uint3 block_colors[4];
+	for (uint32_t s = 0; s < 4; s++) {
+		uint3 block_color = convert_uint3(clamp(base_color + pinten[s], (int)0, 255));
+		block_colors[s] = block_color;
+		block_inten[s] = block_color.x + block_color.y + block_color.z;
+	}
+
+	// evaluate_solution_fast() enforces/assumesd a total ordering of the input colors along the intensity (1,1,1) axis to more quickly classify the inputs to selectors.
+	// The inputs colors have been presorted along the projection onto this axis, and ETC1 block colors are always ordered along the intensity axis, so this classification is fast.
+	// 0   1   2   3
+	//   01  12  23
+	uint32_t block_inten_midpoints[3] = { block_inten[0] + block_inten[1], block_inten[1] + block_inten[2], block_inten[2] + block_inten[3] };
+
+	uint64_t total_error = 0;
+	if ((self->sorted_luma[ETC1_OPTIMIZER_NUM_SRC_PIXELS - 1] * 2) < block_inten_midpoints[0]) {
+		if (block_inten[0] > self->sorted_luma[ETC1_OPTIMIZER_NUM_SRC_PIXELS - 1]) {
+			uint32_t min_error = abs_diff((int)block_inten[0], (int)self->sorted_luma[ETC1_OPTIMIZER_NUM_SRC_PIXELS - 1]);
+			if (min_error >= trial_solution->error)
+				return UINT64_MAX;
+		}
+
+		for (uint32_t c = 0; c < ETC1_OPTIMIZER_NUM_SRC_PIXELS; c++) {
+			selectors[c] = 0;
+			total_error += color_distance_rgb(block_colors[0], unpackVec4(self->pixels[c]).xyz);
+		}
+	} else if ((self->sorted_luma[0] * 2) >= block_inten_midpoints[2]) {
+		if (self->sorted_luma[0] > block_inten[3]) {
+			uint32_t min_error = abs_diff((int)self->sorted_luma[0], (int)block_inten[3]);
+			if (min_error >= trial_solution->error)
+				return UINT64_MAX;
+		}
+
+		for (uint32_t c = 0; c < ETC1_OPTIMIZER_NUM_SRC_PIXELS; c++) {
+			selectors[c] = 3;
+			total_error += color_distance_rgb(block_colors[3], unpackVec4(self->pixels[c]).xyz);
+		}
+	} else {
+		uint32_t cur_selector = 0, c;
+		for (c = 0; c < ETC1_OPTIMIZER_NUM_SRC_PIXELS; c++) {
+			uint32_t y = self->sorted_luma[c];
+			while ((y * 2) >= block_inten_midpoints[cur_selector] && cur_selector < 3) {
+				cur_selector++;
+			}
+			if (cur_selector >= 3) break;
+			uint32_t sorted_pixel_index = self->sorted_luma_indices[c];
+			selectors[sorted_pixel_index] = (cl_uchar)(cur_selector);
+			total_error += color_distance_rgb(block_colors[cur_selector], unpackVec4(self->pixels[sorted_pixel_index]).xyz);
+		}
+		while (c < ETC1_OPTIMIZER_NUM_SRC_PIXELS) {
+			uint32_t sorted_pixel_index = self->sorted_luma_indices[c];
+			selectors[sorted_pixel_index] = 3;
+			total_error += color_distance_rgb(block_colors[3], unpackVec4(self->pixels[sorted_pixel_index]).xyz);
+			++c;
+		}
+	}
+	return total_error;
+}
+
+uint64_t evaluate_solution_slow(TYPEOF_CONST THE_C, __global etc1_optimizer* self, int3 base_color,
+		cl_ulong trial_solution_error, cl_uchar selectors[ETC1_OPTIMIZER_NUM_SRC_PIXELS], int inten_table) {
+	__constant int* pinten = get_inten_table(THE_C, inten_table);
+	uint64_t total_error = 0;
+
+	for (uint32_t c = 0; c < ETC1_OPTIMIZER_NUM_SRC_PIXELS; c++) {
+		uint3 src_pixel = unpackVec4(self->pixels[c]).xyz;
+		uint32_t best_selector_index = 0;
+		uint64_t best_error = UINT64_MAX;
+#if 0
+		if (m_pParams->m_pForce_selectors) {
+			best_selector_index = m_pParams->m_pForce_selectors[c];
+			best_error = color_distance_rgb(src_pixel, block_colors[best_selector_index]);
+		} else
+#endif
+		{
+			for (uint32_t s = 0; s < 4; s++) {
+				uint3 block_color = convert_uint3(clamp(base_color + pinten[s], (int)0, 255));
+				uint64_t err = color_distance_rgb(src_pixel, block_color);
+				if (err < best_error) {
+					best_error = err;
+					best_selector_index = s;
+				}
+			}
+		}
+		selectors[c] = (cl_uchar)(best_selector_index);
+		total_error += best_error;
+		if (total_error > trial_solution_error) {
+			break;
+		}
+	}
+	return total_error;
+}
+
+void evaluate_solution(TYPEOF_CONST THE_C, __global etc1_optimizer* self, const etc1_solution_coordinates* coords,
+		etc1_optimizer_solution* trial_solution) {
+	/*uint32_t k = coords.m_unscaled_color.r | (coords.m_unscaled_color.g << 8) | (coords.m_unscaled_color.b << 16);
+	if (!m_solutions_tried.insert(k).second)
+		return false;*/
+
+	/*m_constrain_against_base_color5 is not implemented yet:
+	if (m_pParams->m_constrain_against_base_color5) {
+		const int dr = (int)coords.m_unscaled_color.r - (int)m_pParams->m_base_color5.r;
+		const int dg = (int)coords.m_unscaled_color.g - (int)m_pParams->m_base_color5.g;
+		const int db = (int)coords.m_unscaled_color.b - (int)m_pParams->m_base_color5.b;
+
+		if ((minimum(dr, dg, db) < cETC1ColorDeltaMin) || (maximum(dr, dg, db) > cETC1ColorDeltaMax))
+		{
+			return false;
+		}
+	}*/
+
+	cl_uchar selectors[ETC1_OPTIMIZER_NUM_SRC_PIXELS];
+	int3 base_color = get_scaled_color(coords).xyz;
+	trial_solution->error = UINT64_MAX;
+#if (ETC1_QUALITY == ETC1_Q_FAST) || (ETC1_QUALITY == ETC1_Q_MED)
+	for (int inten_table = cETC1IntenModifierValues - 1; inten_table >= 0; --inten_table) {
+		uint64_t total_error = evaluate_solution_fast(THE_C, self, base_color, trial_solution, selectors, inten_table);
+#else
+	for (int inten_table = 0; inten_table < cETC1IntenModifierValues; inten_table++) {
+		uint64_t total_error = evaluate_solution_slow(THE_C, self, base_color, trial_solution->error, selectors, inten_table);
+#endif
+
+		if (total_error < trial_solution->error) {
+			for (uint32_t c = 0; c < ETC1_OPTIMIZER_NUM_SRC_PIXELS; c++) {
+				trial_solution->selectors[c] = selectors[c];
+			}
+			trial_solution->error = total_error;
+			trial_solution->coords.flags = inten_table;
+			trial_solution->is_valid = true;
+#if (ETC1_QUALITY == ETC1_Q_FAST) || (ETC1_QUALITY == ETC1_Q_MED)
+			if (!total_error)
+				break;
+#endif
+		}
+	}
+
+	if (trial_solution->error < self->best.error) {
+		self->best.is_valid = true;
+		self->best.coords.unscaled_color = coords->unscaled_color;
+		self->best.coords.flags = (coords->flags & ~ETC1_SOLUTION_INTEN_TABLE_MASK) | trial_solution->coords.flags;
+		self->best.error = trial_solution->error;
+		for (uint32_t c = 0; c < ETC1_OPTIMIZER_NUM_SRC_PIXELS; c++) {
+			self->best.selectors[c] = trial_solution->selectors[c];
+		}
+	}
+}
+
+void etc1_optimizer_compute(TYPEOF_CONST THE_C, __global etc1_optimizer* self) {
+	// inlined function etc1_optimizer_init:
+	self->best.is_valid = false;
+
+#ifdef ETC1_USE_COLOR4
+#define LIMIT 15
+#else
+#define LIMIT 31
+#endif
+	int3 sum = (int3)(0);
+	for (uint32_t i = 0; i < ETC1_OPTIMIZER_NUM_SRC_PIXELS; i++)
+	{
+		uint3 c = unpackVec4(self->pixels[i]).xyz;
+		sum += convert_int3(c);
+		self->luma[i] = (uint16_t)(c.x + c.y + c.z);
+		self->sorted_luma_indices[i] = i;
+	}
+	float3 avg_color = convert_float3(sum) / (float)(ETC1_OPTIMIZER_NUM_SRC_PIXELS);
+	etc1_solution_coordinates coords;
+	coords.unscaled_color = (int4)(clamp(convert_int3(avg_color * (float)LIMIT / 255.0f + .5f), (int)0, LIMIT), 0);
+	coords.flags = 0;
+
+	// begin etc1_optimizer_compute:
+#ifdef ETC1_NO_CLUSTER_FIT
+#error not implemented yet: compute_internal_neighborhood(coords.unscaled_color.r, coords.unscaled_color.g, coords.unscaled_color.b);
+#endif
+
+#ifndef ETC1_QUALITY
+#error Kernel must be compiled with -DETC1_QUALITY=nnn
+#elif ETC1_QUALITY == ETC1_Q_FAST
+#define TOTAL_PERMS_TO_TRY (4)
+#elif ETC1_QUALITY == ETC1_Q_MED
+#define TOTAL_PERMS_TO_TRY (32)
+#elif ETC1_QUALITY == ETC1_Q_SLOW
+#define TOTAL_PERMS_TO_TRY (64)
+#elif ETC1_QUALITY == ETC1_Q_UBER
+#define TOTAL_PERMS_TO_TRY CLUSTER_FIT_ORDER_TABLE_SIZE
+#else
+#error invalid ETC1_QUALITY
+#endif
+
+#if TOTAL_PERMS_TO_TRY <= 32
+	// Sort luma into sorted_luma and sorted_luma_indices.
+	sort_luma(self);
+#endif
+
+	etc1_optimizer_solution trial_solution;
+	// inlined function compute_internal_cluster_fit() here:
+	self->best.error = UINT64_MAX;
+	evaluate_solution(THE_C, self, &coords, &trial_solution);
+
+	if (self->best.error == 0 || !self->best.is_valid) {
+		return;
+	}
+
+	for (uint32_t i = 0; i < TOTAL_PERMS_TO_TRY && self->best.error; i++) {
+		etc1_solution_coordinates base_coords;
+		base_coords.unscaled_color = self->best.coords.unscaled_color;
+		base_coords.flags = self->best.coords.flags;
+		int3 base_color = get_scaled_color(&base_coords).xyz;
+
+      __constant int* pinten = get_inten_table(THE_C, self->best.coords.flags & ETC1_SOLUTION_INTEN_TABLE_MASK);
+		int num_selectors[4];
+		get_cluster_fit_order_tab(THE_C, i, num_selectors);
+		sum = (int3)(0);
+		for (uint32_t q = 0; q < 4; q++) {
+			sum += num_selectors[q] * (clamp(base_color + pinten[q], (int)0, 255) - base_color);
+		}
+
+		if ((!sum.x) && (!sum.y) && (!sum.z)) continue;
+
+		float3 avg_delta = convert_float3(sum) / 8.f;
+		coords.unscaled_color = (int4)(clamp(convert_int3((avg_color - avg_delta) * LIMIT / 255.0f + .5f), (int)0, LIMIT), 0);
+
+		evaluate_solution(THE_C, self, &coords, &trial_solution);
+	}
+#undef LIMIT
+}
+
+__kernel void main(TYPEOF_CONST THE_C, __global etc1_optimizer* states) {
+	#define idx get_global_id(0)
+	#define state (&states[idx])
+	#if 1
+	state->best.q = 41;
+	etc1_optimizer_compute(THE_C, state);
+	#endif
+}

--- a/opencl/ocldevice.cpp
+++ b/opencl/ocldevice.cpp
@@ -1,0 +1,187 @@
+// ocldevice.cpp
+// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "oclhost.h"
+#include "oclhost_internal.h"
+
+namespace basisu
+{
+	const char* clerrstr(cl_int v) {
+		if (v == -1001) {
+			// TODO: check this - AMD bundles -lOpenCL if memory serves.
+			return "-1001: try apt-get install nvidia-opencl-dev";
+		}
+		switch (v) {
+		#define stringify(d) #d
+		#define case_to_string(d) case d: return #d
+			case_to_string(CL_DEVICE_NOT_FOUND);
+			case_to_string(CL_DEVICE_NOT_AVAILABLE);
+			case_to_string(CL_COMPILER_NOT_AVAILABLE);
+			case_to_string(CL_MEM_OBJECT_ALLOCATION_FAILURE);
+			case_to_string(CL_OUT_OF_RESOURCES);
+			case_to_string(CL_OUT_OF_HOST_MEMORY);
+			case_to_string(CL_PROFILING_INFO_NOT_AVAILABLE);
+			case_to_string(CL_MEM_COPY_OVERLAP);
+			case_to_string(CL_IMAGE_FORMAT_MISMATCH);
+			case_to_string(CL_IMAGE_FORMAT_NOT_SUPPORTED);
+			case_to_string(CL_BUILD_PROGRAM_FAILURE);
+			case_to_string(CL_MAP_FAILURE);
+			case_to_string(CL_MISALIGNED_SUB_BUFFER_OFFSET);
+			case_to_string(CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST);
+			case_to_string(CL_COMPILE_PROGRAM_FAILURE);
+			case_to_string(CL_LINKER_NOT_AVAILABLE);
+			case_to_string(CL_LINK_PROGRAM_FAILURE);
+			case_to_string(CL_DEVICE_PARTITION_FAILED);
+			case_to_string(CL_KERNEL_ARG_INFO_NOT_AVAILABLE);
+
+			case_to_string(CL_INVALID_VALUE);
+			case_to_string(CL_INVALID_DEVICE_TYPE);
+			case_to_string(CL_INVALID_PLATFORM);
+			case_to_string(CL_INVALID_DEVICE);
+			case_to_string(CL_INVALID_CONTEXT);
+			case_to_string(CL_INVALID_QUEUE_PROPERTIES);
+			case_to_string(CL_INVALID_COMMAND_QUEUE);
+			case_to_string(CL_INVALID_HOST_PTR);
+			case_to_string(CL_INVALID_MEM_OBJECT);
+			case_to_string(CL_INVALID_IMAGE_FORMAT_DESCRIPTOR);
+			case_to_string(CL_INVALID_IMAGE_SIZE);
+			case_to_string(CL_INVALID_SAMPLER);
+			case_to_string(CL_INVALID_BINARY);
+			case_to_string(CL_INVALID_BUILD_OPTIONS);
+			case_to_string(CL_INVALID_PROGRAM);
+			case_to_string(CL_INVALID_PROGRAM_EXECUTABLE);
+			case_to_string(CL_INVALID_KERNEL_NAME);
+			case_to_string(CL_INVALID_KERNEL_DEFINITION);
+			case_to_string(CL_INVALID_KERNEL);
+			case_to_string(CL_INVALID_ARG_INDEX);
+			case_to_string(CL_INVALID_ARG_VALUE);
+			case_to_string(CL_INVALID_ARG_SIZE);
+			case_to_string(CL_INVALID_KERNEL_ARGS);
+			case_to_string(CL_INVALID_WORK_DIMENSION);
+			case_to_string(CL_INVALID_WORK_GROUP_SIZE);
+			case_to_string(CL_INVALID_WORK_ITEM_SIZE);
+			case_to_string(CL_INVALID_GLOBAL_OFFSET);
+			case_to_string(CL_INVALID_EVENT_WAIT_LIST);
+			case_to_string(CL_INVALID_EVENT);
+			case_to_string(CL_INVALID_OPERATION);
+			case_to_string(CL_INVALID_GL_OBJECT);
+			case_to_string(CL_INVALID_BUFFER_SIZE);
+			case_to_string(CL_INVALID_MIP_LEVEL);
+			case_to_string(CL_INVALID_GLOBAL_WORK_SIZE);
+			case_to_string(CL_INVALID_PROPERTY);
+			case_to_string(CL_INVALID_IMAGE_DESCRIPTOR);
+			case_to_string(CL_INVALID_COMPILER_OPTIONS);
+			case_to_string(CL_INVALID_LINKER_OPTIONS);
+			case_to_string(CL_INVALID_DEVICE_PARTITION_COUNT);
+			case_to_string(CL_INVALID_PIPE_SIZE);
+			case_to_string(CL_INVALID_DEVICE_QUEUE);
+
+		#undef case_to_string
+			default: return "(unknown)";
+		}
+	}
+
+	bool getDeviceInfoAsBuffer(cl_device_id devId, cl_device_info field, void** buf, size_t* len) {
+		size_t llen = 0;
+		cl_int v = clGetDeviceInfo(devId, field, 0, NULL, &llen);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s(%d) failed: %d %s\n", "clGetDeviceInfo", (int)field, v, clerrstr(v));
+			return false;
+		}
+		*buf = malloc(llen);
+		if (!*buf) {
+			fprintf(stderr, "getDeviceInfoAsBuffer(%d): malloc(%zu) failed\n", (int)field, llen);
+			return false;
+		}
+		v = clGetDeviceInfo(devId, field, llen, *buf, NULL);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s(%d) failed: %d %s\n", "clGetDeviceInfo", (int)field, v, clerrstr(v));
+			free(*buf);
+			*buf = NULL;
+			return false;
+		}
+		*len = llen;
+		return true;
+	}
+
+	ocldevice::~ocldevice() {
+		if (ctx) {
+			clReleaseContext(ctx);
+			ctx = NULL;
+		}
+	}
+
+	bool ocldevice::init() {
+		if (!getDeviceInfo(devId, CL_DEVICE_AVAILABLE, info.avail)) {
+			return false;
+		}
+		if (!info.avail) {
+			fprintf(stderr, "CL_DEVICE_AVAILABLE is false\n");
+			return false;
+		}
+		if (!getDeviceInfo(devId, CL_DEVICE_COMPILER_AVAILABLE, info.avail)) {
+			return false;
+		}
+		if (!info.avail) {
+			fprintf(stderr, "CL_DEVICE_COMPILER_AVAILABLE is false\n");
+			return false;
+		}
+		if (!(getDeviceInfo(devId, CL_DEVICE_GLOBAL_MEM_SIZE, info.globalMemSize) &&
+				getDeviceInfo(devId, CL_DEVICE_LOCAL_MEM_SIZE, info.localMemSize) &&
+				getDeviceInfo(devId, CL_DEVICE_MAX_COMPUTE_UNITS, info.maxCU) &&
+				getDeviceInfo(devId, CL_DEVICE_MAX_WORK_GROUP_SIZE, info.maxWG) &&
+				getDeviceInfo(devId, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, info.maxWI) &&
+				getDeviceInfo(devId, CL_DEVICE_NAME, info.name) &&
+				getDeviceInfo(devId, CL_DEVICE_VENDOR, info.vendor) &&
+				getDeviceInfo(devId, CL_DEVICE_VERSION, info.openclver) &&
+				getDeviceInfo(devId, CL_DRIVER_VERSION, info.driver))) {
+			return false;
+		}
+
+		score = info.globalMemSize / 1048576;
+		score *= info.maxCU;
+		score *= info.maxWG;
+		return true;
+	}
+
+	void ocldevice::dump(FILE* out) {
+		fprintf(out, "  %s: %6.1fGB / %lluKB. CU=%u WG=%zu (v%s) %s %s\n",
+				info.name.c_str(), ((float) info.globalMemSize / 1048576.0f) / 1024.0f,
+				(unsigned long long) info.localMemSize / 1024, info.maxCU, info.maxWG,
+				info.driver.c_str(), info.vendor.c_str(), info.openclver.c_str());
+	}
+
+	void ocldevice::unloadPlatformCompiler() {
+		clUnloadPlatformCompiler(platId);
+	}
+
+	bool ocldevice::openCtx(const cl_context_properties* props) {
+		cl_int v = CL_SUCCESS;
+		ctx = clCreateContext(props, 1 /*numDevs*/, &devId, ocldevice::oclErrorCb, this /*user_data*/, &v);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clCreateContext", v, clerrstr(v));
+			return false;
+		}
+		return true;
+	}
+
+	void ocldevice::oclErrorCb(const char *errMsg,
+			/* binary and binary_size are implementation-specific data */
+			const void */*binary*/, size_t /*binary_size*/, void *user_data) {
+		BASISU_NOTE_UNUSED(user_data);
+		fprintf(stderr, "oclErrorCb: \"%s\"\n", errMsg);
+	}
+
+} // namespace basisu

--- a/opencl/oclfrontend.cpp
+++ b/opencl/oclfrontend.cpp
@@ -1,0 +1,151 @@
+// oclhost.cpp
+// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "oclhost.h"
+#include "oclhost_internal.h"
+
+namespace basisu
+{
+
+#define STRINGIFY2(x) #x
+#define STRINGIFY(x) STRINGIFY2(x)
+	bool oclfrontend::init(oclhostprivate& ctx, std::string commonOptions /*= ""*/) {
+		if (ctx.frontendSrc.empty()) {  // Should only need to load the source once.
+			ctx.frontendSrc = oclhost::getSourceFor("opencl/frontend.c");
+			if (ctx.frontendSrc.empty()) {  // if oclhost::getSourceFor() failed, exit.
+				return false;
+			}
+		}
+
+		prog.code = ctx.frontendSrc;
+		prog.options = " -DETC1_QUALITY=";
+		prog.funcName = "main";
+		if (ctx.params.m_compression_level == BASISU_MAX_COMPRESSION_LEVEL) {
+			prog.options += STRINGIFY(ETC1_Q_UBER);
+			fprintf(stderr, "BASISU_MAX_COMPRESSION_LEVEL: OpenCL not implemented\n");
+			return false;
+		} else if (ctx.params.m_compression_level == 0) {
+			prog.options += STRINGIFY(ETC1_Q_FAST);
+		} else {
+			prog.options += STRINGIFY(ETC1_Q_SLOW);
+		}
+		if (!ctx.params.m_perceptual) {
+			prog.options += " -DETC1_NO_PERCEPTUAL=1";
+		}
+		if (ctx.use_color4) {
+			prog.options += " -DETC1_USE_COLOR4=1";
+		}
+		if (!prog.open(commonOptions)) {
+			fprintf(stderr, "oclfrontend.open: prog.open(\"%s\") failed\n", prog.funcName.c_str());
+			return false;
+		}
+		return true;
+	}
+
+	bool oclfrontend::run(oclhostprivate& ctx, oclqueue& q, size_t stateSize, const std::vector<pixel_block>& pixel_blocks) {
+		if (ctx.gConst.empty()) {
+			ctx.gConst.emplace_back();
+			memset(&ctx.gConst[0], 0, sizeof(ctx.gConst[0]));
+			memcpy(&ctx.gConst[0].g_etc1_inten_tables[0][0], &g_etc1_inten_tables[0][0], sizeof(ctx.gConst[0].g_etc1_inten_tables));
+			if (CLUSTER_FIT_ORDER_TABLE_SIZE != BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE) {
+				fprintf(stderr, "BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE = %d (error in oclfrontend_api.h)\n",
+						(int)BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE);
+				return false;
+			}
+			for (size_t i = 0; i < BASISU_ETC1_CLUSTER_FIT_ORDER_TABLE_SIZE; i++) {
+				cl_uint v = 0;
+				for (size_t q = 0; q < 4; q++) {
+					v |= g_cluster_fit_order_tab[i].m_v[q] << (8*q);
+				}
+				ctx.gConst[0].g_cluster_fit_order_tab[i] = v;
+			}
+		}
+		if (!constant.createInput(q, ctx.gConst)) {
+			fprintf(stderr, "constant.createInput failed\n");
+			return false;
+		}
+		if (!q.writeBuffer(constant.getHandle(), ctx.gConst)) {
+			fprintf(stderr, "writeBuffer(constant) failed\n");
+			return false;
+		}
+
+		state.resize(stateSize);
+		result.resize(stateSize);
+		std::vector<ocl::etc1_optimizer> onestate;
+		onestate.resize(1);
+		if (!gpustate.createIO(q, onestate, stateSize)) {
+			fprintf(stderr, "gpuState.createIO failed: stateSize=%zu\n", stateSize);
+			return false;
+		}
+		if (!prog.setArg(0, constant) || !prog.setArg(1, gpustate)) {
+			fprintf(stderr, "prog.setArg failed\n");
+			return false;
+		}
+
+		ocl::etc1_optimizer_params init_params;
+		memset(&init_params, 0, sizeof(init_params));
+
+		for (size_t i = 0; i < state.size(); i++) {
+			auto* pix = pixel_blocks.at(i).get_ptr();
+
+			memcpy(&state.at(i).params, &init_params, sizeof(state[0].params));
+			memcpy(&state.at(i).pixels, pix, sizeof(pix[0]) * ETC1_OPTIMIZER_NUM_SRC_PIXELS);
+		}
+
+		if (!q.writeBuffer(gpustate.getHandle(), state)) {
+			fprintf(stderr, "writeBuffer(gpustate) failed\n");
+			return false;
+		}
+
+		std::vector<size_t> global_work_size{ stateSize };
+		size_t* local_size = NULL;  // OpenCL does better at choosing local_size.
+		if (!q.NDRangeKernel(prog, global_work_size.size(), NULL,  global_work_size.data(), local_size)) {
+			fprintf(stderr, "NDRangeKernel failed\n");
+			return false;
+		}
+		if (!gpustate.copyTo(q, result, completeEvent)) {
+			fprintf(stderr, "gpustate.copyTo or finish failed\n");
+			return false;
+		}
+		return true;
+	}
+
+	float oclfrontend::submitTime() {
+		cl_ulong submitT, endT;
+		if (completeEvent.getSubmitTime(submitT)) {
+			fprintf(stderr, "submitTime: getSubmitTime failed\n");
+			return 0;
+		}
+		if (completeEvent.getEndTime(endT)) {
+			fprintf(stderr, "submitTime: getEndTime failed\n");
+			return 0;
+		}
+		return float(endT - submitT) * 1e-9;
+	}
+
+	float oclfrontend::execTime() {
+		cl_ulong startT, endT;
+		if (completeEvent.getStartTime(startT)) {
+			fprintf(stderr, "submitTime: getStartTime failed\n");
+			return 0;
+		}
+		if (completeEvent.getEndTime(endT)) {
+			fprintf(stderr, "submitTime: getEndTime failed\n");
+			return 0;
+		}
+		return float(endT - startT) * 1e-9;
+	}
+
+} // namespace basisu

--- a/opencl/oclfrontend_api.h
+++ b/opencl/oclfrontend_api.h
@@ -1,0 +1,72 @@
+// oclfrontend_api.h
+// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define ETC1_Q_FAST (0x0000)
+#define ETC1_Q_MED  (0x0001)
+#define ETC1_Q_SLOW (0x0002)
+#define ETC1_Q_UBER (0x0003)
+
+#define cPixelBlockWidth (4)
+#define cPixelBlockHeight (4)
+#define cPixelBlockTotalPixels (cPixelBlockWidth * cPixelBlockHeight)
+
+#define cETC1SelectorBits (2)
+#define cETC1SelectorValues (1U << cETC1SelectorBits)
+#define cETC1SelectorMask (1 - cETC1SelectorValues)
+
+#define cETC1IntenModifierNumBits (3)
+#define cETC1IntenModifierValues (1U << cETC1IntenModifierNumBits)
+#define cETC1RightIntenModifierTableBitOffset (34)
+#define cETC1LeftIntenModifierTableBitOffset (37)
+
+#define CLUSTER_FIT_ORDER_TABLE_SIZE (165)
+
+typedef struct opencl_const {
+	cl_int g_etc1_inten_tables[cETC1IntenModifierValues][cETC1SelectorValues];
+	cl_uint g_cluster_fit_order_tab[CLUSTER_FIT_ORDER_TABLE_SIZE];
+} opencl_const;
+
+typedef struct etc1_pack_params {
+	cl_float flip_bias;
+} etc1_pack_params;
+
+#define ETC1_OPTIMIZER_NUM_SRC_PIXELS (cPixelBlockTotalPixels)
+typedef struct etc1_optimizer_params {
+	etc1_pack_params pack;
+	cl_uint flags;
+} etc1_optimizer_params;
+
+#define ETC1_SOLUTION_INTEN_TABLE_MASK (0x00ff)
+typedef struct etc1_solution_coordinates {
+	cl_int4 unscaled_color;
+	cl_uint flags;
+} etc1_solution_coordinates;
+
+typedef struct etc1_optimizer_solution {
+	etc1_solution_coordinates coords;
+	cl_uchar selectors[ETC1_OPTIMIZER_NUM_SRC_PIXELS];
+	cl_ulong error;
+	cl_uint is_valid;
+	cl_uint q;
+} etc1_optimizer_solution;
+
+typedef struct etc1_optimizer {
+	cl_uint pixels[ETC1_OPTIMIZER_NUM_SRC_PIXELS];
+	cl_uint luma[ETC1_OPTIMIZER_NUM_SRC_PIXELS];
+	cl_uint sorted_luma_indices[ETC1_OPTIMIZER_NUM_SRC_PIXELS];
+	cl_uint sorted_luma[ETC1_OPTIMIZER_NUM_SRC_PIXELS];
+	etc1_optimizer_solution best;
+	etc1_optimizer_params params;
+} etc1_optimizer;

--- a/opencl/oclhost.cpp
+++ b/opencl/oclhost.cpp
@@ -1,0 +1,320 @@
+// oclhost.cpp
+// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "oclhost.h"
+#include "oclhost_internal.h"
+#include "basisu_frontend.h"
+
+namespace basisu
+{
+	static bool getPlatforms(std::vector<cl_platform_id>& platforms) {
+		cl_uint platformIdMax = 0;
+		cl_int v = clGetPlatformIDs(0, NULL, &platformIdMax);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clGetPlatformIDs", v, clerrstr(v));
+			return false;
+		}
+
+		platforms.resize(platformIdMax);
+		v = clGetPlatformIDs(platformIdMax, platforms.data(), NULL);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clGetPlatformIDs", v, clerrstr(v));
+			return false;
+		}
+		return true;
+	}
+
+	static bool getDeviceIds(cl_platform_id platform, std::vector<cl_device_id>& devs) {
+		cl_uint devMax = 0;
+		cl_int v = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, NULL, &devMax);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clGetDeviceIDs", v, clerrstr(v));
+			return false;
+		}
+		devs.resize(devMax);
+		v = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devMax, devs.data(), NULL);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clGetDeviceIDs", v, clerrstr(v));
+			return false;
+		}
+		return true;
+	}
+
+	std::string oclhost::getSourceFor(const char* filename) {
+#if 1
+		std::string r("#include \"");
+		r = r + filename + "\"\n";
+		return r;
+#else
+		FILE* f = fopen(filename, "r");
+		if (!f) {
+			fprintf(stderr, "Unable to read OpenCL source %s: %d %s\n", filename, errno, strerror(errno));
+			return "";
+		}
+		std::vector<char> r(16*1024);
+		size_t used = 0;
+		while (!feof(f)) {
+			size_t nread = fread(&r[0] + used, 1, r.size() - used, f);
+			if (!nread) {
+				if (feof(f)) {
+					break;
+				}
+				fclose(f);
+				fprintf(stderr, "fread OpenCL source %s failed: %d %s\n", filename, errno, strerror(errno));
+				return "";
+			}
+			used += nread;
+			if (used >= r.size() - 1 /*reserve space for a null byte*/) {
+				r.resize(r.size() * 2);
+			}
+		}
+		fclose(f);
+		r.resize(used + 1);
+		r[used] = 0;  // Append a null byte
+		return std::string(r.data(), r.size());
+#endif
+	}
+
+	oclhost::~oclhost() {
+		if (internal) {
+			delete internal;
+			internal = nullptr;
+		}
+	}
+
+	bool oclhost::init(const basisu_frontend::params& params, bool use_color4) {
+		if (!internal) {
+			internal = new oclhostprivate;
+			if (!internal) {
+				fprintf(stderr, "new oclhostprivate failed\n");
+				return false;
+			}
+		}
+		memcpy(&internal->params, &params, sizeof(internal->params));
+		internal->use_color4 = use_color4;
+
+		std::vector<cl_platform_id> platforms;
+		if (!getPlatforms(platforms)) {
+			return false;
+		}
+		if (platforms.size() < 1) {
+			fprintf(stderr, "no OpenCL hardware found.\n");
+			return false;
+		}
+
+		for (size_t i = 0; i < platforms.size(); i++) {
+			std::vector<cl_device_id> devIDs;
+			if (!getDeviceIds(platforms.at(i), devIDs)) {
+				return false;
+			}
+
+			float bestScore = 0.0f;
+			for (size_t j = 0; j < devIDs.size(); j++) {
+				devs.emplace_back(std::make_shared<ocldevice>(platforms.at(i), devIDs.at(j)));
+				auto dev = devs.back();
+				if (!dev->init()) {
+					return false;
+				}
+				if (j == 0 || dev->score > bestScore) {
+					bestScore = dev->score;
+					// Any time the best is upped, delete everything else
+					devs.clear();
+					devs.emplace_back(dev);
+				} else if (dev->score < bestScore) {
+					// Any device that scores too poorly is dropped.
+					devs.pop_back();
+				}
+			}
+		}
+		if (devs.size() < 1) {
+			fprintf(stderr, "no OpenCL devices selected - BUG?\n");
+			return false;
+		}
+		if (!initDevs()) {
+			return false;
+		}
+		for (auto dev : devs) {
+			dev->unloadPlatformCompiler();
+		}
+		return true;
+	}
+
+	bool oclhost::initDevs() {
+		fprintf(stderr, "Using these OpenCL devices:\n");
+		for (auto dev : devs) {
+			dev->dump(stderr);
+
+			// ctxProps is a list terminated with a "0, 0" pair.
+			const cl_context_properties ctxProps[] = {
+				// Specify the OpenCL platform for the device.
+				CL_CONTEXT_PLATFORM,
+				reinterpret_cast<cl_context_properties>(dev->platId),
+				0, 0,  // 0, 0, to terminate the list.
+			};
+			if (!dev->openCtx(ctxProps)) {
+				return false;
+			}
+			// Compile, link oclprogram objects.
+			const char* mainFuncName = "main";
+
+			// This is controlled differently on AMD: see
+			// __attribute__((reqd_work_group_size(64,1,1))) such as in
+			// https://community.amd.com/thread/158594
+			std::string commonOptions;
+			if (dev->info.vendor.find("NVIDIA") != std::string::npos) {
+				commonOptions += " -cl-nv-verbose -cl-nv-maxrregcount=128";
+			}
+			dev->frontend = std::make_shared<oclfrontend>(*dev);
+			if (!dev->frontend->init(*internal, commonOptions)) {
+				fprintf(stderr, "frontend.open failed\n");
+				return false;
+			}
+		}
+		return true;
+	}
+
+
+
+
+	// clpool manages in-flight input and output buffers for each kernel invocation.
+	// OpenCL devices stay busy when the next kernel is submitted before the last one
+	// is finished, so clpool generates work to submit in advance and manages cleanup.
+	//
+	// TODO: not implemented yet.
+	struct clpool {
+		clpool(ocldevice& dev, oclhostprivate& ctx)
+				: dev(dev), maxCU(dev.info.maxCU), ctx(ctx) {}
+
+		ocldevice& dev;
+		oclqueue q{dev};
+
+		bool open(size_t n) {
+			if (!q.open()) {
+				fprintf(stderr, "clpool: q.open failed\n");
+				return false;
+			}
+			setNumWorkers(n);
+			return true;
+		}
+
+		// setNumWorkers sets the control parameters to assign work to each worker.
+		void setNumWorkers(size_t n) {
+			numWorkers = n;
+		}
+
+		size_t getNumWorkers() const { return numWorkers; }
+
+	protected:
+		const cl_uint maxCU;
+		size_t numWorkers;
+		oclhostprivate& ctx;
+	};
+
+	bool oclhost::runFrontend(const std::vector<pixel_block>& pixel_blocks) {
+		if (devs.size() < 1) {
+			fprintf(stderr, "runFrontend: no devs\n");
+			return false;
+		} else if (devs.size() > 1) {
+			fprintf(stderr, "WARNING: only using first dev. Multi-dev has not been tested yet.\n");
+		}
+
+		std::vector<clpool> pool;
+		pool.reserve(devs.size());
+		size_t workLeft = pixel_blocks.size();
+		for (size_t i = 0; i < devs.size(); i++) {
+			pool.emplace_back(*devs.at(i), *internal);
+			if (!pool.at(i).open(workLeft)) {
+				fprintf(stderr, "pool[%zu].open failed\n", i);
+				return false;
+			}
+			workLeft -= workLeft;
+		}
+
+		fprintf(stderr, "\e[32mrunFrontend: start kernels\e[0m\n");
+		for (size_t i = 0; i < devs.size(); i++) {
+			if (!devs.at(i)->frontend->run(*internal, pool.at(i).q, pool.at(i).getNumWorkers(), pixel_blocks)) {
+				fprintf(stderr, "clpool: dev.frontend.run failed\n");
+				return false;
+			}
+			if (1) {
+				fprintf(stderr, "cpu: dev[%zu]: %zu blocks\n", i, devs.at(i)->frontend->state.size());
+			}
+		}
+		fprintf(stderr, "runFrontend: wait kernels\n");
+		for (size_t i = 0; i < devs.size(); i++) {
+			devs.at(i)->frontend->completeEvent.waitForSignal();
+		}
+		fprintf(stderr, "runFrontend: DONE.\n");
+		internal->results.clear();
+		for (size_t i = 0; i < devs.size(); i++) {
+			for (auto& r : devs.at(i)->frontend->result) {
+				internal->results.push_back(r.best);
+			}
+		}
+		return true;
+	}
+
+	void oclhost::check_results(const std::vector<etc_block>& cpu_results) {
+		int num_err = 0;
+		for (size_t i = 0; i < cpu_results.size() && i < internal->results.size(); i++) {
+			auto& r = cpu_results.at(i);
+			auto rc = r.unpack_color5(r.get_base5_color(), false);
+
+			auto& p = internal->results.at(i);
+			cl_uint pc[4];
+			memcpy(&pc[0], &p.coords.unscaled_color, sizeof(pc));
+			bool match = pc[3] == 0;
+			for (uint32_t y = 0; y < 4; y++) {
+				for (uint32_t x = 0; x < 4; x++) {
+					uint32_t rs = r.get_selector(x, y);
+					uint32_t os = p.selectors[x + y * 4];
+					match = (rs == os) ? match : false;
+				}
+			}
+			if (!match) {
+				num_err++;
+				if (num_err > 10) {
+					continue;
+				}
+				fprintf(stderr, "cpu_results[%zu]: inten:%x  #%02x,%02x,%02x sel=", i, r.get_inten_table(0), rc.r, rc.g, rc.b);
+				for (uint32_t y = 0; y < 4; y++) {
+					for (uint32_t x = 0; x < 4; x++) {
+						uint32_t rs = r.get_selector(x, y);
+						fprintf(stderr, " %u", rs);
+					}
+				}
+				fprintf(stderr, "\ngpu_results[%zu]: inten:%x  #%02x,%02x,%02x", i,
+						p.coords.flags & ETC1_SOLUTION_INTEN_TABLE_MASK, pc[0], pc[1], pc[2]);
+				if (pc[3]) {
+					fprintf(stderr, " %x", pc[3]);
+				}
+				fprintf(stderr, " sel=");
+				for (uint32_t y = 0; y < 4; y++) {
+					for (uint32_t x = 0; x < 4; x++) {
+						uint32_t os = p.selectors[x + y * 4];
+						fprintf(stderr, " %u", os);
+					}
+				}
+				fprintf(stderr, " q=%d\n", (int)p.q);
+			}
+			// blk.set_flip_bit(true);
+		}
+		if (internal->results.size() == 0) {
+			fprintf(stderr, "cpu_results not checked - gpu_results empty.\n");
+		} else {
+			fprintf(stderr, "cpu_results all match gpu_results? %s\n", (num_err == 0) ? "YES" : "\e[31mNO\e[0m");
+		}
+	}
+} // namespace basisu

--- a/opencl/oclhost.h
+++ b/opencl/oclhost.h
@@ -1,0 +1,103 @@
+// oclhost.h
+// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include "basisu_frontend.h"
+
+// OpenCL header is defined differently on different platforms
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
+#include "CL/cl.h"
+#endif
+
+namespace basisu
+{
+	// Forward declarations:
+	class oclfrontend;
+	class oclqueue;
+	class oclmemory;
+	struct oclhostprivate;
+
+	// ocldevice is used internally by oclhost.
+	class ocldevice {
+	public:
+		ocldevice(cl_platform_id platId, cl_device_id devId) : platId(platId), devId(devId), ctx(NULL) {}
+		~ocldevice();
+
+		// init populates score and DevInfo info.
+		bool init();
+
+		void dump(FILE* out);
+		void unloadPlatformCompiler();
+
+		// openCtx is a wrapper for clCreateContext.
+		bool openCtx(const cl_context_properties* props);
+		cl_context getContext() const { return ctx; }
+
+		const cl_platform_id platId;
+		const cl_device_id devId;
+
+		// score is to allow oclhost to automatically select the "best" device.
+		// TODO: use of all devices in the system is not implemented yet.
+		float score;
+
+		struct DevInfo {
+			cl_bool avail;
+			cl_ulong globalMemSize;
+			cl_ulong localMemSize;
+			cl_uint maxCU;
+			size_t maxWG;
+			cl_uint maxWI;
+			std::string name;
+			std::string vendor;
+			std::string openclver;
+			std::string driver;
+		} info;
+
+		std::shared_ptr<oclfrontend> frontend;
+
+	private:
+		cl_context ctx;
+
+		static void oclErrorCb(const char *errMsg,
+				/* binary and binary_size are implementation-specific data */
+				const void */*binary*/, size_t /*binary_size*/, void *user_data);
+	};
+
+	// class oclhost wraps OpenCL init.
+	// It also exposes functions to run OpenCL kernels and retrieve the results.
+	class oclhost {
+		BASISU_NO_EQUALS_OR_COPY_CONSTRUCT(oclhost);
+	public:
+		oclhost() {}
+		~oclhost();
+
+		// init selects OpenCL device(s) to use.
+		bool init(const basisu_frontend::params& params, bool use_color4);
+
+		// runFrontend runs basisu_frontend on OpenCL device(s).
+		bool runFrontend(const std::vector<pixel_block>& pixel_blocks);
+
+		void check_results(const std::vector<etc_block>& cpu_results);
+
+		static std::string getSourceFor(const char* filename);
+
+	private:
+		std::vector<std::shared_ptr<ocldevice>> devs;
+		bool initDevs();
+		oclhostprivate* internal{nullptr};
+	};
+
+} // namespace basisu

--- a/opencl/oclhost_internal.h
+++ b/opencl/oclhost_internal.h
@@ -1,0 +1,398 @@
+// oclhost_internal.h
+// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+namespace ocl
+{
+#include "oclfrontend_api.h"
+} // namespace ocl
+
+namespace basisu
+{
+	const char* clerrstr(cl_int v);
+	bool getDeviceInfoAsBuffer(cl_device_id devId, cl_device_info field, void** buf, size_t* len);
+
+	template<typename T>
+	inline bool getDeviceInfo(cl_device_id devId, cl_device_info field, T& out) {
+		void* r;
+		size_t len;
+		if (!getDeviceInfoAsBuffer(devId, field, &r, &len)) {
+			return false;
+		}
+		if (len != sizeof(out)) {
+			fprintf(stderr, "getDeviceInfo(%d): size %zu, want %zu\n", (int)field,
+					len, sizeof(out));
+			return false;
+		}
+		memcpy(&out, r, sizeof(out));
+		free(r);
+		return true;
+	}
+
+	template<>
+	inline bool getDeviceInfo(cl_device_id devId, cl_device_info field, std::string& out) {
+		void* r;
+		size_t len;
+		if (!getDeviceInfoAsBuffer(devId, field, &r, &len)) {
+			return false;
+		}
+		out.assign(reinterpret_cast<const char*>(r), len);
+		free(r);
+		return true;
+	}
+
+	class oclprogram {
+	public:
+		oclprogram(ocldevice& dev) : dev(dev), prog(NULL), kern(NULL) {}
+		~oclprogram() {
+			if (kern) {
+				clReleaseKernel(kern);
+				kern = NULL;
+			}
+			if (prog) {
+				clReleaseProgram(prog);
+				prog = NULL;
+			}
+		}
+
+		// open should only be called after code, options and funcName are set.
+		// Allows a cleaner separation between device code (which just needs an
+		// oclprogrma) and implementation code (which has the particulars on how to
+		// set up memory buffers, what the options are, etc.)
+		//
+		// commonOptions can be passed in to specify options for all oclprograms.
+		bool open(std::string commonOptions = "");
+
+		ocldevice& dev;
+		std::string code;
+		std::string options;
+		std::string funcName;
+
+		char* getBuildLog() {
+			return reinterpret_cast<char*>(getProgramBuildInfo(CL_PROGRAM_BUILD_LOG));
+		}
+
+		template<typename T>
+		bool setArg(cl_uint argIndex, const T& arg) {
+			if (!kern) {
+				fprintf(stderr, "setArg(%u) before open\n", argIndex);
+				return false;
+			}
+			cl_int v = clSetKernelArg(kern, argIndex, sizeof(arg), reinterpret_cast<const void*>(&arg));
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s(%u) failed: %d %s\n", "clSetKernelArg", argIndex, v,
+						clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		cl_kernel getKern() const { return kern; }
+		bool copyFrom(oclprogram& other, const char* mainFuncName) {
+			prog = other.prog;
+			cl_int v;
+			kern = clCreateKernel(prog, mainFuncName, &v);
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "clCreateKernel", v, clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+	private:
+		void* getProgramBuildInfo(cl_program_build_info field);
+
+		cl_program prog;
+		cl_kernel kern;
+	};
+
+	class oclevent {
+	public:
+		oclevent() : handle(NULL) {}
+		~oclevent() {
+			clReleaseEvent(handle);
+		}
+
+		void waitForSignal() {
+			clWaitForEvents(1, &handle);
+		}
+
+		bool getQueuedTime(cl_ulong& t) {
+			return getProfilingInfo(CL_PROFILING_COMMAND_QUEUED, t);
+		}
+
+		bool getSubmitTime(cl_ulong& t) {
+			return getProfilingInfo(CL_PROFILING_COMMAND_SUBMIT, t);
+		}
+
+		bool getStartTime(cl_ulong& t) {
+			return getProfilingInfo(CL_PROFILING_COMMAND_START, t);
+		}
+
+		bool getEndTime(cl_ulong& t) {
+			return getProfilingInfo(CL_PROFILING_COMMAND_END, t);
+		}
+
+		bool getProfilingInfo(cl_profiling_info param, cl_ulong& out) {
+			if (!handle) {
+				fprintf(stderr, "Event must first be passed to an Enqueue... function\n");
+				return false;
+			}
+			size_t size_ret = 0;
+			cl_int v = clGetEventProfilingInfo(handle, param, sizeof(out), &out, &size_ret);
+			if (v != CL_PROFILING_INFO_NOT_AVAILABLE && size_ret != sizeof(out)) {
+				fprintf(stderr, "%s: told to provide %zu bytes, want %zu bytes\n",
+						"oclevent::getProfilingInfo", size_ret, sizeof(out));
+			}
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "oclevent::getProfilingInfo", v, clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		cl_event handle;
+	};
+
+	class oclqueue {
+	public:
+		oclqueue(ocldevice& dev) : dev(dev), handle(NULL) {}
+
+		~oclqueue() {
+			if (handle) {
+				clReleaseCommandQueue(handle);
+				handle = NULL;
+			}
+		}
+
+		bool open(std::vector<cl_queue_properties> props = std::vector<cl_queue_properties>{
+					CL_QUEUE_PROPERTIES, CL_QUEUE_PROFILING_ENABLE,
+				}) {
+			if (handle) {
+				fprintf(stderr, "validation: oclqueue::open called twice\n");
+				return false;
+			}
+			cl_queue_properties* pprops = NULL;
+			if (props.size()) {
+				// Make sure props includes the required terminating 0.
+				props.push_back(0);
+				pprops = props.data();
+			}
+			cl_int v;
+			handle = clCreateCommandQueueWithProperties(
+				dev.getContext(), dev.devId, pprops, &v);
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "clCreateCommandQueue", v,
+						clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		// writeBuffer does a non-blocking write
+		template<typename T>
+		bool writeBuffer(cl_mem hnd, const std::vector<T>& src) {
+			cl_int v = clEnqueueWriteBuffer(handle, hnd, CL_FALSE /*blocking*/, 0 /*offset*/,
+				sizeof(src[0]) * src.size(), reinterpret_cast<const void*>(src.data()), 0, NULL, NULL);
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "clEnqueueWriteBuffer", v,
+						clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		// writeBuffer does a non-blocking write and outputs the cl_event that
+		// will be signalled when it completes.
+		template<typename T>
+		bool writeBuffer(cl_mem hnd, const std::vector<T>& src, cl_event& complete) {
+			cl_int v = clEnqueueWriteBuffer(handle, hnd, CL_FALSE /*blocking*/, 0 /*offset*/,
+				sizeof(src[0]) * src.size(), reinterpret_cast<const void*>(src.data()), 0, NULL, &complete);
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "clEnqueueWriteBuffer", v, clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		// readBuffer does a blocking read
+		template<typename T>
+		bool readBuffer(cl_mem hnd, std::vector<T>& dst) {
+			cl_int v = clEnqueueReadBuffer(handle, hnd, CL_TRUE /*blocking*/, 0 /*offset*/,
+				sizeof(dst[0]) * dst.size(), reinterpret_cast<void*>(dst.data()), 0, NULL, NULL);
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "clEnqueueReadBuffer", v, clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		// readBufferNonBlock does a non-blocking read
+		template<typename T>
+		bool readBufferNonBlock(cl_mem hnd, std::vector<T>& dst, cl_event& complete) {
+			cl_int v = clEnqueueReadBuffer(handle, hnd, CL_FALSE /*blocking*/, 0 /*offset*/,
+				sizeof(dst[0]) * dst.size(), reinterpret_cast<void*>(dst.data()), 0, NULL, &complete);
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "clEnqueueReadBuffer", v, clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		ocldevice& dev;
+
+		bool NDRangeKernel(oclprogram& prog, cl_uint work_dim,
+								const size_t* global_work_offset,
+								const size_t* global_work_size,
+								const size_t* local_work_size,
+								cl_event* completeEvent = NULL,
+								const std::vector<cl_event>& waitList
+										= std::vector<cl_event>()) {
+			cl_int v = clEnqueueNDRangeKernel(handle, prog.getKern(), work_dim,
+														global_work_offset,
+														global_work_size, local_work_size,
+														waitList.size(), waitList.data(),
+														completeEvent);
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "clEnqueueNDRangeKernel", v, clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		bool NDRangeKernel(oclprogram& prog, cl_uint work_dim,
+								const size_t* global_work_offset,
+								const size_t* global_work_size,
+								const size_t* local_work_size,
+								oclevent& completeEvent,
+								const std::vector<cl_event>& waitList
+										= std::vector<cl_event>()) {
+			return NDRangeKernel(prog, work_dim, global_work_offset, global_work_size,
+										local_work_size, &completeEvent.handle, waitList);
+		}
+
+		bool finish() {
+			cl_int v = clFinish(handle);
+			if (v != CL_SUCCESS) {
+				fprintf(stderr, "%s failed: %d %s\n", "clFinish", v, clerrstr(v));
+				return false;
+			}
+			return true;
+		}
+
+		private:
+		cl_command_queue handle;
+	};
+
+	class oclmemory {
+	public:
+		oclmemory(ocldevice& dev) : dev(dev), handle(NULL) {}
+		virtual ~oclmemory() {
+			if (handle) {
+				clReleaseMemObject(handle);
+				handle = NULL;
+			}
+		}
+		ocldevice& dev;
+
+		bool create(cl_mem_flags flags, size_t size);
+
+		template<typename T>
+		bool createInput(oclqueue& q, std::vector<T>& in, size_t copies = 1) {
+			if (!create(CL_MEM_READ_ONLY, sizeof(in[0]) * in.size() * copies)) {
+				fprintf(stderr, "createInput failed\n");
+				return false;
+			}
+			if (copies == 1) {
+				if (!q.writeBuffer(getHandle(), in)) {
+					fprintf(stderr, "createInput: writeBuffer failed\n");
+					return false;
+				}
+			}
+			return true;
+		}
+
+		template<typename T>
+		bool createIO(oclqueue& q, std::vector<T>& in, size_t copies = 1) {
+			if (!create(CL_MEM_READ_WRITE, sizeof(in[0]) * in.size() * copies)) {
+				fprintf(stderr, "createIO failed\n");
+				return false;
+			}
+			if (copies == 1) {
+				if (!q.writeBuffer(getHandle(), in)) {
+					fprintf(stderr, "createIO: writeBuffer failed\n");
+					return false;
+				}
+			}
+			return true;
+		}
+
+		template<typename T>
+		bool createOutput(std::vector<T>& out) {
+			// The oclqueue::readBuffer() call is done using copyTo, below.
+			return create(CL_MEM_WRITE_ONLY, sizeof(out[0]) * out.size());
+		}
+
+		template<typename T>
+		bool copyTo(oclqueue& q, std::vector<T>& out) {
+			return q.readBuffer(getHandle(), out);
+		}
+
+		template<typename T>
+		bool copyTo(oclqueue& q, std::vector<T>& out, oclevent& completeEvent) {
+			return q.readBufferNonBlock(getHandle(), out, completeEvent.handle);
+		}
+
+		cl_mem getHandle() const { return handle; }
+
+		private:
+		cl_mem handle;
+	};
+
+	template<>
+	inline bool oclprogram::setArg(cl_uint argIndex, const oclmemory& mem) {
+		return setArg(argIndex, mem.getHandle());
+	};
+
+	struct oclhostprivate {
+		// Inputs to frontend
+		basisu_frontend::params params;
+		bool use_color4;
+		std::string frontendSrc;
+		std::vector<ocl::opencl_const> gConst;
+
+		// Combined output from all devices after frontend
+		std::vector<ocl::etc1_optimizer_solution> results;
+	};
+
+	class oclfrontend {
+	public:
+		oclfrontend(ocldevice& dev) : prog(dev), constant(dev), gpustate(dev) {}
+		oclprogram prog;
+		oclmemory constant;
+		oclmemory gpustate;
+		oclevent completeEvent;
+		std::vector<ocl::etc1_optimizer> state;
+		std::vector<ocl::etc1_optimizer> result;
+
+		bool init(oclhostprivate& ctx, std::string commonOptions = "");
+
+		bool run(oclhostprivate& ctx, oclqueue& q, size_t stateSize, const std::vector<pixel_block>& pixel_blocks);
+
+		float submitTime();
+		float execTime();
+	};
+
+} // namespace basisu

--- a/opencl/oclprogram.cpp
+++ b/opencl/oclprogram.cpp
@@ -1,0 +1,104 @@
+// oclprogram.cpp
+// Copyright (C) 2019 Binomial LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "oclhost.h"
+#include "oclhost_internal.h"
+
+namespace basisu
+{
+
+	bool oclmemory::create(cl_mem_flags flags, size_t size) {
+		if (handle) {
+			fprintf(stderr, "validation: oclmemory::create called twice\n");
+			return false;
+		}
+		cl_int v;
+		handle = clCreateBuffer(dev.getContext(), flags, size, NULL, &v);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clCreateBuffer", v, clerrstr(v));
+			return false;
+		}
+		return true;
+	}
+
+	static void printBuildLog(char* log) {
+		if (!log) {
+			return;
+		}
+		if (strspn(log, "\r\n") != strlen(log)) {
+			fprintf(stderr, "%s", log);
+			if (strlen(log) && log[strlen(log) - 1] != '\n') {
+				fprintf(stderr, "\n");
+			}
+		}
+		free(log);
+		return;
+	}
+
+	bool oclprogram::open(std::string commonOptions /*= ""*/) {
+		if (prog) {
+			fprintf(stderr, "validation: oclprogram::open called twice\n");
+			return false;
+		}
+		const char* codePtr = code.c_str();
+		cl_int v;
+		prog = clCreateProgramWithSource(dev.getContext(), 1, &codePtr, NULL, &v);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clCreateProgramWithSource", v,
+					clerrstr(v));
+			return false;
+		}
+
+		commonOptions += options;
+		v = clBuildProgram(prog, 1, &dev.devId, commonOptions.c_str(), NULL, NULL);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clBuildProgram", v, clerrstr(v));
+			printBuildLog(getBuildLog());
+			return false;
+		}
+		printBuildLog(getBuildLog());
+
+		kern = clCreateKernel(prog, funcName.c_str(), &v);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clCreateKernel", v, clerrstr(v));
+			return false;
+		}
+		return true;
+	}
+
+	void* oclprogram::getProgramBuildInfo(cl_program_build_info field) {
+		size_t len = 0;
+		cl_int v = clGetProgramBuildInfo(prog, dev.devId, field, 0, NULL, &len);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clGetProgramBuildInfo", v,
+						clerrstr(v));
+			return NULL;
+		}
+		void* mem = malloc(len);
+		if (!mem) {
+			fprintf(stderr, "%s malloc failed\n", "clGetProgramBuildInfo");
+			return NULL;
+		}
+		v = clGetProgramBuildInfo(prog, dev.devId, field, len, mem, NULL);
+		if (v != CL_SUCCESS) {
+			fprintf(stderr, "%s failed: %d %s\n", "clGetProgramBuildInfo", v,
+						clerrstr(v));
+			free(mem);
+			return NULL;
+		}
+		return mem;
+	}
+
+}  // namespace basisu


### PR DESCRIPTION
**This is a start, but I wouldn't ship this as-is. Hoping to get early feedback.**

This adds an OpenCL implementation of the compressor.

Currently this can only do etc1_optimizer_compute() on a GPU. It still does the
CPU etc1_optimizer_compute() to check the results. In the future, GPU/CPU
checking would only be done if an extra flag was passed in.

This also compiles the OpenCL source at runtime - good for debug builds so
the error message shows the source line number. Release builds should pull
the OpenCL source into the binary, instead of looking for it in the filesystem.