### PR TITLE
Fixes to enable libktx use of Basis

### DIFF
--- a/basisu_astc_decomp.cpp
+++ b/basisu_astc_decomp.cpp
@@ -39,6 +39,12 @@
 #define DE_LENGTH_OF_ARRAY(x) (sizeof(x)/sizeof(x[0]))
 #define DE_UNREF(x) (void)x
 
+#if __GNUC__ || __clang__
+  #define DE_MAYBE_UNUSED __attribute__((unused))
+#else
+  #define DE_MAYBE_UNUSED
+#endif
+
 typedef uint8_t deUint8;
 typedef int8_t deInt8;
 typedef uint32_t deUint32;
@@ -52,12 +58,12 @@ typedef uint64_t deUint64;
 
 namespace basisu_astc
 {
-	static bool inBounds(int v, int l, int h)
+	static bool  DE_MAYBE_UNUSED inBounds(int v, int l, int h)
 	{
 		return (v >= l) && (v < h);
 	}
 
-	static bool inRange(int v, int l, int h)
+	static bool  DE_MAYBE_UNUSED inRange(int v, int l, int h)
 	{
 		return (v >= l) && (v <= h);
 	}
@@ -192,7 +198,7 @@ namespace basisu_astc
 		return (a + b - 1) / b;
 	}
 
-	static bool deInBounds32(uint32_t v, uint32_t l, uint32_t h)
+	static bool  DE_MAYBE_UNUSED deInBounds32(uint32_t v, uint32_t l, uint32_t h)
 	{
 		return (v >= l) && (v < h);
 	}

--- a/basisu_backend.cpp
+++ b/basisu_backend.cpp
@@ -176,7 +176,7 @@ namespace basisu
 	void basisu_backend::reoptimize_and_sort_endpoints_codebook(uint32_t total_block_endpoints_remapped, uint_vec& all_endpoint_indices)
 	{
 		basisu_frontend& r = *m_pFront_end;
-		const bool is_video = r.get_params().m_tex_type == basist::cBASISTexTypeVideoFrames;
+		//const bool is_video = r.get_params().m_tex_type == basist::cBASISTexTypeVideoFrames;
 
 		if ((total_block_endpoints_remapped) && (m_params.m_compression_level > 0))
 		{
@@ -201,10 +201,7 @@ namespace basisu
 
 			for (uint32_t slice_index = 0; slice_index < m_slices.size(); slice_index++)
 			{
-				const uint32_t first_block_index = m_slices[slice_index].m_first_block_index;
-
-				const uint32_t width = m_slices[slice_index].m_width;
-				const uint32_t height = m_slices[slice_index].m_height;
+				//const uint32_t first_block_index = m_slices[slice_index].m_first_block_index;
 				const uint32_t num_blocks_x = m_slices[slice_index].m_num_blocks_x;
 				const uint32_t num_blocks_y = m_slices[slice_index].m_num_blocks_y;
 
@@ -212,7 +209,7 @@ namespace basisu
 				{
 					for (uint32_t block_x = 0; block_x < num_blocks_x; block_x++)
 					{
-						const uint32_t block_index = first_block_index + block_x + block_y * num_blocks_x;
+						//const uint32_t block_index = first_block_index + block_x + block_y * num_blocks_x;
 
 						encoder_block& m = m_slice_encoder_blocks[slice_index](block_x, block_y);
 
@@ -336,10 +333,7 @@ namespace basisu
 		for (uint32_t slice_index = 0; slice_index < m_slices.size(); slice_index++)
 		{
 			const bool is_iframe = m_slices[slice_index].m_iframe;
-			const uint32_t first_block_index = m_slices[slice_index].m_first_block_index;
 
-			const uint32_t width = m_slices[slice_index].m_width;
-			const uint32_t height = m_slices[slice_index].m_height;
 			const uint32_t num_blocks_x = m_slices[slice_index].m_num_blocks_x;
 			const uint32_t num_blocks_y = m_slices[slice_index].m_num_blocks_y;
 			const int prev_frame_slice_index = find_video_frame(slice_index, -1);
@@ -411,8 +405,6 @@ namespace basisu
 			const bool is_iframe = m_slices[slice_index].m_iframe;
 			const uint32_t first_block_index = m_slices[slice_index].m_first_block_index;
 
-			const uint32_t width = m_slices[slice_index].m_width;
-			const uint32_t height = m_slices[slice_index].m_height;
 			const uint32_t num_blocks_x = m_slices[slice_index].m_num_blocks_x;
 			const uint32_t num_blocks_y = m_slices[slice_index].m_num_blocks_y;
 
@@ -590,7 +582,6 @@ namespace basisu
 	{
 		for (uint32_t slice_index = 0; slice_index < m_slices.size(); slice_index++)
 		{
-			const uint32_t first_block_index = m_slices[slice_index].m_first_block_index;
 			const uint32_t width = m_slices[slice_index].m_width;
 			const uint32_t height = m_slices[slice_index].m_height;
 			const uint32_t num_blocks_x = m_slices[slice_index].m_num_blocks_x;
@@ -603,7 +594,7 @@ namespace basisu
 			{
 				for (uint32_t block_x = 0; block_x < num_blocks_x; block_x++)
 				{
-					const uint32_t block_index = first_block_index + block_x + block_y * num_blocks_x;
+					//const uint32_t block_index = first_block_index + block_x + block_y * num_blocks_x;
 
 					encoder_block& m = m_slice_encoder_blocks[slice_index](block_x, block_y);
 
@@ -680,11 +671,9 @@ namespace basisu
 
 		for (uint32_t slice_index = 0; slice_index < m_slices.size(); slice_index++)
 		{
-			const int prev_frame_slice_index = is_video ? find_video_frame(slice_index, -1) : -1;
-			const int next_frame_slice_index = is_video ? find_video_frame(slice_index, 1) : -1;
+			//const int prev_frame_slice_index = is_video ? find_video_frame(slice_index, -1) : -1;
+			//const int next_frame_slice_index = is_video ? find_video_frame(slice_index, 1) : -1;
 			const uint32_t first_block_index = m_slices[slice_index].m_first_block_index;
-			const uint32_t width = m_slices[slice_index].m_width;
-			const uint32_t height = m_slices[slice_index].m_height;
 			const uint32_t num_blocks_x = m_slices[slice_index].m_num_blocks_x;
 			const uint32_t num_blocks_y = m_slices[slice_index].m_num_blocks_y;
 
@@ -702,7 +691,7 @@ namespace basisu
 			{
 				for (uint32_t block_x = 0; block_x < num_blocks_x; block_x++)
 				{
-					const uint32_t block_index = first_block_index + block_x + block_y * num_blocks_x;
+					//const uint32_t block_index = first_block_index + block_x + block_y * num_blocks_x;
 
 					encoder_block& m = m_slice_encoder_blocks[slice_index](block_x, block_y);
 
@@ -1168,8 +1157,6 @@ namespace basisu
 
 		for (uint32_t slice_index = 0; slice_index < m_slices.size(); slice_index++)
 		{
-			const uint32_t width = m_slices[slice_index].m_width;
-			const uint32_t height = m_slices[slice_index].m_height;
 			const uint32_t num_blocks_x = m_slices[slice_index].m_num_blocks_x;
 			const uint32_t num_blocks_y = m_slices[slice_index].m_num_blocks_y;
 
@@ -1644,7 +1631,7 @@ namespace basisu
 
 	uint32_t basisu_backend::encode()
 	{
-		const bool is_video = m_pFront_end->get_params().m_tex_type == basist::cBASISTexTypeVideoFrames;
+		//const bool is_video = m_pFront_end->get_params().m_tex_type == basist::cBASISTexTypeVideoFrames;
 		m_output.m_slice_desc = m_slices;
 		m_output.m_etc1s = m_params.m_etc1s;
 

--- a/basisu_comp.cpp
+++ b/basisu_comp.cpp
@@ -494,14 +494,14 @@ namespace basisu
 			}
 		}
 
-		printf("Total basis file slices: %u\n", (uint32_t)m_slice_descs.size());
+		debug_printf("Total basis file slices: %u\n", (uint32_t)m_slice_descs.size());
 
 		for (uint32_t i = 0; i < m_slice_descs.size(); i++)
 		{
 			const basisu_backend_slice_desc &slice_desc = m_slice_descs[i];
 
-			printf("Slice: %u, alpha: %u, orig width/height: %ux%u, width/height: %ux%u, first_block: %u, image_index: %u, mip_level: %u, iframe: %u\n", 
-				i, slice_desc.m_alpha, slice_desc.m_orig_width, slice_desc.m_orig_height, slice_desc.m_width, slice_desc.m_height, slice_desc.m_first_block_index, slice_desc.m_source_file_index, slice_desc.m_mip_index, slice_desc.m_iframe);
+			debug_printf("Slice: %u, alpha: %u, orig width/height: %ux%u, width/height: %ux%u, first_block: %u, image_index: %u, mip_level: %u, iframe: %u\n",
+				i, slice_desc.m_alpha, slice_desc.m_orig_width, slice_desc.m_orig_height, slice_desc.m_width, slice_desc.m_height, slice_desc.m_first_block_index, slice_desc.m_source_file_index,      slice_desc.m_mip_index, slice_desc.m_iframe);
 
 			if (m_any_source_image_has_alpha)
 			{

--- a/basisu_enc.cpp
+++ b/basisu_enc.cpp
@@ -25,6 +25,14 @@
 #include <windows.h>
 #endif
 
+#ifdef max
+#undef max
+#endif
+
+#ifdef min
+#undef min
+#endif
+
 namespace basisu
 {
 	uint64_t interval_timer::g_init_ticks, interval_timer::g_freq;
@@ -1057,7 +1065,7 @@ namespace basisu
 		uint32_t max_count = 0, max_index = 0;
 		for (uint32_t i = 0; i < num_syms * num_syms; i++)
 			if (m_hist[i] > max_count)
-				max_count = m_hist[i], max_index = i;
+              static_cast<void>(max_count = m_hist[i]), max_index = i;
 
 		uint32_t a = max_index / num_syms, b = max_index % num_syms;
 

--- a/basisu_enc.h
+++ b/basisu_enc.h
@@ -1238,8 +1238,6 @@ namespace basisu
 
 		bool prep_split(const tsvq_node &node, TrainingVectorType &l_child_result, TrainingVectorType &r_child_result) const
 		{
-			const uint32_t N = TrainingVectorType::num_elements;
-
 			if (2 == node.m_training_vecs.size())
 			{
 				l_child_result = m_training_vecs[node.m_training_vecs[0]].first;

--- a/basisu_etc.cpp
+++ b/basisu_etc.cpp
@@ -657,7 +657,6 @@ namespace basisu
 		if (m_best_solution.m_error == 0)
 			return;
 
-		const uint32_t n = m_pParams->m_num_src_pixels;
 		const int scan_delta_size = m_pParams->m_scan_delta_size;
 
 		// Scan through a subset of the 3D lattice centered around the avg block color trying each 3D (555 or 444) lattice point as a potential block color.

--- a/basisu_etc.h
+++ b/basisu_etc.h
@@ -116,7 +116,7 @@ namespace basisu
 		{
 			assert((ofs + num) <= 64U);
 			assert(num && (num < 32U));
-			return (read_be64(&m_uint64) >> ofs) & ((1UL << num) - 1UL);
+			return (uint32_t)((read_be64(&m_uint64) >> ofs) & ((1UL << num) - 1UL));
 		}
 
 		inline void set_general_bits(uint32_t ofs, uint32_t num, uint32_t bits)

--- a/basisu_frontend.cpp
+++ b/basisu_frontend.cpp
@@ -17,10 +17,15 @@
 // This code originally supported full ETC1 and ETC1S, so there's some legacy stuff to be cleaned up in here.
 // Add endpoint tiling support (where we force adjacent blocks to use the same endpoints during quantization), for a ~10% or more increase in bitrate at same SSIM. The backend already supports this.
 //
+#define _CRT_SECURE_NO_WARNINGS
 #include "transcoder/basisu.h"
 #include "basisu_frontend.h"
 #include <unordered_set>
 #include <unordered_map>
+
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
 
 #define BASISU_FRONTEND_VERIFY(c) do { if (!(c)) handle_verify_failure(__LINE__); } while(0)
 
@@ -29,7 +34,7 @@ namespace basisu
 	const uint32_t cMaxCodebookCreationThreads = 8;
 
 	const uint32_t BASISU_MAX_ENDPOINT_REFINEMENT_STEPS = 3;
-	const uint32_t BASISU_MAX_SELECTOR_REFINEMENT_STEPS = 3;
+	//const uint32_t BASISU_MAX_SELECTOR_REFINEMENT_STEPS = 3;
 
 	const uint32_t BASISU_ENDPOINT_PARENT_CODEBOOK_SIZE = 16;
 	const uint32_t BASISU_SELECTOR_PARENT_CODEBOOK_SIZE = 16;
@@ -837,8 +842,6 @@ namespace basisu
 				continue;
 #endif
 
-			const uint32_t new_endpoint_cluster_index = (uint32_t)m_endpoint_clusters.size();
-
 			enlarge_vector(m_endpoint_clusters, 1)->push_back(training_vector_index);
 			enlarge_vector(m_endpoint_cluster_etc_params, 1);
 
@@ -1085,8 +1088,6 @@ namespace basisu
 
 				for (uint32_t block_index = first_index; block_index < last_index; block_index++)
 				{
-					const bool is_flipped = true;
-			
 					const uint32_t cluster_index = block_clusters[block_index][0];
 					BASISU_FRONTEND_VERIFY(cluster_index == block_clusters[block_index][1]);
 
@@ -1938,7 +1939,6 @@ namespace basisu
 
 						const uint32_t block_index = training_vector_index >> 1;
 						const uint32_t subblock_index = training_vector_index & 1;
-						const bool is_flipped = true;
 
 						etc_block &blk = m_encoded_blocks[block_index];
 

--- a/basisu_gpu_texture.cpp
+++ b/basisu_gpu_texture.cpp
@@ -1415,7 +1415,12 @@ namespace basisu
 		return write_compressed_texture_file(pFilename, v, false);
 	}
 
-	const uint32_t OUT_FILE_MAGIC = 'TEXC';
+	// Can't find docs. I'm assuming order in file should be "TEXC". Since
+	// uint32_t's are written in little endian order we need to put T in the
+	// low order byte, etc.
+	const uint32_t OUT_FILE_MAGIC =
+	        'T' | ('E' << 8) | ('X' << 16) | ('C' << 24);
+
 	struct out_file_header 
 	{
 		packed_uint<4> m_magic;

--- a/basisu_resample_filters.cpp
+++ b/basisu_resample_filters.cpp
@@ -283,7 +283,7 @@ namespace basisu
 		return sum;
 	}
 
-	static const float KAISER_ALPHA = 4.0;
+	//static const float KAISER_ALPHA = 4.0;
 	static double kaiser(double alpha, double half_width, double x)
 	{
 		const double ratio = (x / half_width);

--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -86,7 +86,7 @@
 
 #define BASISU_NOTE_UNUSED(x) (void)(x)
 #define BASISU_ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
-#define BASISU_NO_EQUALS_OR_COPY_CONSTRUCT(x) x(const x &) = delete; x& operator= (const x &) = delete;
+#define BASISU_NO_EQUALS_OR_COPY_CONSTRUCT(x) x(const x &) = delete; x& operator= (const x &) = delete
 #define BASISU_ASSUME(x) static_assert(x, #x);
 #define BASISU_OFFSETOF(s, m) (uint32_t)(intptr_t)(&((s *)(0))->m)
 #define BASISU_STRINGIZE(x) #x

--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -272,7 +272,7 @@ namespace basist
 	{ \
 		{ N * -8,  N * -2,   N * 2,   N * 8 },{ N * -17,  N * -5,  N * 5,  N * 17 },{ N * -29,  N * -9,   N * 9,  N * 29 },{ N * -42, N * -13, N * 13,  N * 42 }, \
 		{ N * -60, N * -18, N * 18,  N * 60 },{ N * -80, N * -24, N * 24,  N * 80 },{ N * -106, N * -33, N * 33, N * 106 },{ N * -183, N * -47, N * 47, N * 183 } \
-	};
+	}
 
 	DECLARE_ETC1_INTEN_TABLE(g_etc1_inten_tables, 1);
 	DECLARE_ETC1_INTEN_TABLE(g_etc1_inten_tables16, 16);
@@ -917,7 +917,7 @@ namespace basist
 	// encoding from LSB to MSB: low8, high8, error16, size is [32*8][NUM_ETC1_TO_BC7_M6_SELECTOR_RANGES][NUM_ETC1_TO_BC7_M6_SELECTOR_MAPPINGS]
 	extern const uint32_t* g_etc1_to_bc7_m6_table[];
 
-	const uint16_t s_bptc_table_aWeight4[16] = { 0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64 };
+	//const uint16_t s_bptc_table_aWeight4[16] = { 0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64 };
 
 #if BASISD_WRITE_NEW_BC7_TABLES
 	static void create_etc1_to_bc7_m6_conversion_table()
@@ -1267,6 +1267,7 @@ namespace basist
 #endif
 
 #if BASISD_SUPPORT_ETC2_EAC_A8 || BASISD_SUPPORT_ETC2_EAC_RG11
+#if 0 // Table not used.
 	static const int8_t g_eac_modifier_table[16][8] =
 	{
 		{ -3, -6, -9, -15, 2, 5, 8, 14 },
@@ -1287,6 +1288,7 @@ namespace basist
 		{ -4, -6, -8, -9, 3, 5, 7, 8 },
 		{ -3, -5, -7, -9, 2, 4, 6, 8 }
 	};
+ #endif
 
 	// Used by ETC2 EAC A8 and ETC2 EAC R11/RG11.
 	struct eac_block
@@ -3302,6 +3304,7 @@ namespace basist
 		}
 	};
 
+#if 0
 	static const uint8_t g_pvrtc_bilinear_weights[16][4] =
 	{
 		{ 4, 4, 4, 4 }, { 2, 6, 2, 6 }, { 8, 0, 8, 0 }, { 6, 2, 6, 2 },
@@ -3309,6 +3312,7 @@ namespace basist
 		{ 8, 8, 0, 0 }, { 4, 12, 0, 0 }, { 16, 0, 0, 0 }, { 12, 4, 0, 0 },
 		{ 6, 6, 2, 2 }, { 3, 9, 1, 3 }, { 12, 0, 4, 0 }, { 9, 3, 3, 1 },
 	};
+#endif
 
 	struct pvrtc1_temp_block
 	{
@@ -3409,7 +3413,7 @@ namespace basist
 		const uint32_t x_bits = basisu::total_bits(x_mask);
 		const uint32_t y_bits = basisu::total_bits(y_mask);
 		const uint32_t min_bits = basisu::minimum(x_bits, y_bits);
-		const uint32_t max_bits = basisu::maximum(x_bits, y_bits);
+		//const uint32_t max_bits = basisu::maximum(x_bits, y_bits);
 		const uint32_t swizzle_mask = (1 << (min_bits * 2)) - 1;
 
 		uint32_t block_index = 0;
@@ -3590,7 +3594,7 @@ namespace basist
 		const uint32_t x_bits = basisu::total_bits(x_mask);
 		const uint32_t y_bits = basisu::total_bits(y_mask);
 		const uint32_t min_bits = basisu::minimum(x_bits, y_bits);
-		const uint32_t max_bits = basisu::maximum(x_bits, y_bits);
+		//const uint32_t max_bits = basisu::maximum(x_bits, y_bits);
 		const uint32_t swizzle_mask = (1 << (min_bits * 2)) - 1;
 
 		uint32_t block_index = 0;
@@ -6253,10 +6257,12 @@ namespace basist
 	static const etc1s_to_atc_solution g_etc1s_to_pvrtc2_45[32 * 8 * NUM_ETC1S_TO_ATC_SELECTOR_MAPPINGS * NUM_ETC1S_TO_ATC_SELECTOR_RANGES] = {
 #include "basisu_transcoder_tables_pvrtc2_45.inc"
 	};
-		
+
+#if 0 // table not used
 	static const etc1s_to_atc_solution g_etc1s_to_pvrtc2_alpha_33[32 * 8 * NUM_ETC1S_TO_ATC_SELECTOR_MAPPINGS * NUM_ETC1S_TO_ATC_SELECTOR_RANGES] = {
 #include "basisu_transcoder_tables_pvrtc2_alpha_33.inc"
 	};
+#endif
 #endif
 
 	static const etc1s_to_atc_solution g_etc1s_to_atc_55[32 * 8 * NUM_ETC1S_TO_ATC_SELECTOR_MAPPINGS * NUM_ETC1S_TO_ATC_SELECTOR_RANGES] = {
@@ -7166,7 +7172,7 @@ namespace basist
 
 	typedef struct { float c[4]; } vec4F;
 
-	static inline int32_t clampi(int32_t value, int32_t low, int32_t high) { if (value < low) value = low; else if (value > high) value = high;	return value; }
+	//static inline int32_t clampi(int32_t value, int32_t low, int32_t high) { if (value < low) value = low; else if (value > high) value = high;	return value; }
 	static inline float clampf(float value, float low, float high) { if (value < low) value = low; else if (value > high) value = high;	return value; }
 	static inline float saturate(float value) { return clampf(value, 0, 1.0f); }
 	static inline vec4F* vec4F_set_scalar(vec4F* pV, float x) { pV->c[0] = x; pV->c[1] = x; pV->c[2] = x;	pV->c[3] = x;	return pV; }
@@ -7646,7 +7652,7 @@ namespace basist
 
 					uint32_t m = (le * 5 + he * 3) / 8;
 
-					int err = labs((int)v - (int)m);
+					int err = (int)labs((int)v - (int)m);
 					if (err < lowest_err)
 					{
 						lowest_err = err;
@@ -7669,7 +7675,7 @@ namespace basist
 				uint32_t le = (l << 1);
 				le = (le << 4) | le;
 
-				int err = labs((int)v - (int)le);
+				int err = (int)labs((int)v - (int)le);
 				if (err < lowest_err)
 				{
 					lowest_err = err;
@@ -7691,7 +7697,7 @@ namespace basist
 				uint32_t he = (h << 1) | 1;
 				he = (he << 4) | he;
 
-				int err = labs((int)v - (int)he);
+				int err = (int)labs((int)v - (int)he);
 				if (err < lowest_err)
 				{
 					lowest_err = err;
@@ -7720,7 +7726,7 @@ namespace basist
 
 					uint32_t m = (le * 5 + he * 3) / 8;
 
-					int err = labs((int)v - (int)m);
+					int err = (int)labs((int)v - (int)m);
 					if (err < lowest_err)
 					{
 						lowest_err = err;
@@ -7750,7 +7756,7 @@ namespace basist
 
 					uint32_t m = (le * 5 + he * 3) / 8;
 
-					int err = labs((int)v - (int)m);
+					int err = (int)labs((int)v - (int)m);
 					if (err < lowest_err)
 					{
 						lowest_err = err;
@@ -8134,7 +8140,7 @@ namespace basist
 	}
 
 	bool basisu_lowlevel_transcoder::transcode_slice(void* pDst_blocks, uint32_t num_blocks_x, uint32_t num_blocks_y, const uint8_t* pImage_data, uint32_t image_data_size, block_format fmt,
-		uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const basis_file_header& header, const basis_slice_desc& slice_desc, uint32_t output_row_pitch_in_blocks_or_pixels,
+		uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const bool is_video, const bool alpha_flag, const uint32_t level_index, const uint32_t orig_width, const uint32_t orig_height, uint32_t output_row_pitch_in_blocks_or_pixels,
 		basisu_transcoder_state* pState, bool transcode_alpha, void *pAlpha_blocks, uint32_t output_rows_in_pixels)
 	{
 		(void)transcode_alpha;
@@ -8143,17 +8149,16 @@ namespace basist
 		if (!pState)
 			pState = &m_def_state;
 
-		const bool is_video = (header.m_tex_type == cBASISTexTypeVideoFrames);
 		const uint32_t total_blocks = num_blocks_x * num_blocks_y;
 
 		if (!output_row_pitch_in_blocks_or_pixels)
 		{
 			if (basis_block_format_is_uncompressed(fmt))
-				output_row_pitch_in_blocks_or_pixels = slice_desc.m_orig_width;
+				output_row_pitch_in_blocks_or_pixels = orig_width;
 			else
 			{
 				if (fmt == block_format::cFXT1_RGB)
-					output_row_pitch_in_blocks_or_pixels = (slice_desc.m_orig_width + 7) / 8;
+					output_row_pitch_in_blocks_or_pixels = (orig_width + 7) / 8;
 				else
 					output_row_pitch_in_blocks_or_pixels = num_blocks_x;
 			}
@@ -8162,16 +8167,13 @@ namespace basist
 		if (basis_block_format_is_uncompressed(fmt))
 		{
 			if (!output_rows_in_pixels)
-				output_rows_in_pixels = slice_desc.m_orig_height;
+				output_rows_in_pixels = orig_height;
 		}
 		
 		std::vector<uint32_t>* pPrev_frame_indices = nullptr;
 		if (is_video)
 		{
 			// TODO: Add check to make sure the caller hasn't tried skipping past p-frames
-			const bool alpha_flag = (slice_desc.m_flags & cSliceDescFlagsIsAlphaData) != 0;
-			const uint32_t level_index = slice_desc.m_level_index;
-
 			if (level_index >= basisu_transcoder_state::cMaxPrevFrameLevels)
 			{
 				BASISU_DEVEL_ERROR("basisu_lowlevel_transcoder::transcode_slice: unsupported level_index\n");
@@ -9585,7 +9587,7 @@ namespace basist
 		return -1;
 	}
 
-	static void write_opaque_alpha_blocks(
+	void basisu_transcoder::write_opaque_alpha_blocks(
 		uint32_t num_blocks_x, uint32_t num_blocks_y,
 		void* pOutput_blocks, uint32_t output_blocks_buf_size_in_blocks_or_pixels, block_format fmt,
 		uint32_t block_stride_in_bytes, uint32_t output_row_pitch_in_blocks_or_pixels)

--- a/transcoder/basisu_transcoder.h
+++ b/transcoder/basisu_transcoder.h
@@ -139,8 +139,19 @@ namespace basist
 		bool decode_tables(const uint8_t *pTable_data, uint32_t table_data_size);
 
 		bool transcode_slice(void *pDst_blocks, uint32_t num_blocks_x, uint32_t num_blocks_y, const uint8_t *pImage_data, uint32_t image_data_size, block_format fmt, 
-			uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const basis_file_header &header, const basis_slice_desc& slice_desc, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
+			uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const bool video_flag, const bool alpha_flag, const uint32_t level_index, const uint32_t orig_width, const uint32_t orig_height, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
 			basisu_transcoder_state *pState = nullptr, bool astc_transcode_alpha = false, void* pAlpha_blocks = nullptr, uint32_t output_rows_in_pixels = 0);
+
+		bool transcode_slice(void *pDst_blocks, uint32_t num_blocks_x, uint32_t num_blocks_y, const uint8_t *pImage_data, uint32_t image_data_size, block_format fmt, 
+			uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const basis_file_header &header, const basis_slice_desc& slice_desc, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
+			basisu_transcoder_state *pState = nullptr, bool astc_transcode_alpha = false, void* pAlpha_blocks = nullptr, uint32_t output_rows_in_pixels = 0)
+		{
+			return transcode_slice(pDst_blocks, num_blocks_x, num_blocks_y, pImage_data, image_data_size, fmt, output_block_or_pixel_stride_in_bytes, bc1_allow_threecolor_blocks,
+								   header.m_tex_type == cBASISTexTypeVideoFrames, (slice_desc.m_flags & cSliceDescFlagsIsAlphaData) != 0, slice_desc.m_level_index, slice_desc.m_orig_width, slice_desc.m_orig_height, output_row_pitch_in_blocks_or_pixels, pState,
+                                       astc_transcode_alpha,
+                                       pAlpha_blocks,
+                                       output_rows_in_pixels);
+		}
 
 	private:
 		typedef std::vector<endpoint> endpoint_vec;
@@ -353,6 +364,10 @@ namespace basist
 		bool transcode_slice(const void *pData, uint32_t data_size, uint32_t slice_index, 
 			void *pOutput_blocks, uint32_t output_blocks_buf_size_in_blocks_or_pixels,
 			block_format fmt, uint32_t output_block_stride_in_bytes, uint32_t decode_flags = 0, uint32_t output_row_pitch_in_blocks_or_pixels = 0, basisu_transcoder_state * pState = nullptr, void* pAlpha_blocks = nullptr, uint32_t output_rows_in_pixels = 0) const;
+
+	   static void write_opaque_alpha_blocks(uint32_t num_blocks_x, uint32_t num_blocks_y,
+			void* pOutput_blocks, uint32_t output_blocks_buf_size_in_blocks, block_format fmt,
+			uint32_t block_stride_in_bytes, uint32_t output_row_pitch_in_blocks);
 
 	private:
 		mutable basisu_lowlevel_transcoder m_lowlevel_decoder;


### PR DESCRIPTION
This PR does the following:

Enables access to the low-level decoder:
- Makes a new signature for transcode_slice that does not require faking up bits of a .basis file. A function with the old signature remains as an inline function that calls the new one.
- Makes `write_opaque_blocks` a public static function of `lowlevel_decoder.`

Enables embedding of the basis code within a library to be linked to applications:
- Changes the setting of _ITERATOR_DEBUG_LEVEL to the default VS value. There appears to be absolutely no need to set this value or _SECURE_SCL within these files.

Fixes all the unused variable warnings which totalled about 45.

It does NOT fix other -pedantic warnings which include one about misuse of a comma operator and 9 about anonymous structs and unions being extensions. There is also 1 unused variable warning that appears when compiled in release mode that this PR does not fix.

Please turn on -pedantic and fix them.