### PR TITLE
Win32: Fix build with GCC (MinGW)

### DIFF
--- a/basisu_enc.h
+++ b/basisu_enc.h
@@ -23,7 +23,7 @@
 #include <thread>
 #include <unordered_map>
 
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(__MINGW32__)
 #include <libgen.h>
 #endif
 


### PR DESCRIPTION
Cf. https://github.com/godotengine/godot/issues/32384.

Build error without this patch:
```
$ cmake .. -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw64.cmake
Initial BUILD_X64=ON
Initial CMAKE_BUILD_TYPE=
basisu build type: Release
Building 64-bit
-- Configuring done
-- Generating done
-- Build files have been written to: /home/akien/Projects/godot/godot.git/thirdparty/bu.git/build
[akien@cauldron build (master)]$ rm * -rf
[akien@cauldron build (master)]$ git up
remote: Enumerating objects: 5, done.
remote: Counting objects: 100% (5/5), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 3 (delta 2), reused 0 (delta 0), pack-reused 0
Unpacking objects: 100% (3/3), done.
From https://github.com/BinomialLLC/basis_universal
   d33443a..9a63bb6  master     -> origin/master
Updating d33443a..9a63bb6
Fast-forward
 README.md | 2 ++
 1 file changed, 2 insertions(+)
Current branch master is up to date.
[akien@cauldron build (master)]$ cmake .. -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw64.cmake
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/x86_64-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/x86_64-w64-mingw32-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/x86_64-w64-mingw32-g++
-- Check for working CXX compiler: /usr/bin/x86_64-w64-mingw32-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
Initial BUILD_X64=ON
Initial CMAKE_BUILD_TYPE=
basisu build type: Release
Building 64-bit
-- Configuring done
-- Generating done
-- Build files have been written to: /home/akien/Projects/godot/godot.git/thirdparty/bu.git/build
[akien@cauldron build (master)]$ make
Scanning dependencies of target basisu
[  5%] Building CXX object CMakeFiles/basisu.dir/basisu_backend.cpp.obj
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:18,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_enc.h: In function 'bool basisu::string_split_path(const char*, std::__cxx11::string*, std::__cxx11::string*, std::__cxx11::string*, std::__cxx11::string*)':
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_enc.h:748:26: error: 'dirname' was not declared in this scope
   const char *pDirName = dirname(dirtmp);
                          ^~~~~~~
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_enc.h:748:26: note: suggested alternative: 'pDirName'
   const char *pDirName = dirname(dirtmp);
                          ^~~~~~~
                          pDirName
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_enc.h:749:27: error: 'basename' was not declared in this scope
   const char* pBaseName = basename(nametmp);
                           ^~~~~~~~
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_enc.h:749:27: note: suggested alternative: 'pBaseName'
   const char* pBaseName = basename(nametmp);
                           ^~~~~~~~
                           pBaseName
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:17,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h: In instantiation of 'void basisu::clear_obj(T&) [with T = basist::etc1_global_palette_entry_modifier]':
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu_global_selector_palette.h:71:27:   required from here
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h:122:62: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'class basist::etc1_global_palette_entry_modifier'; use assignment or value-initialization instead [-Wclass-memaccess]
  template <typename T> inline void clear_obj(T& obj) { memset(&obj, 0, sizeof(obj)); }
                                                        ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:20,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu_global_selector_palette.h:21:8: note: 'class basist::etc1_global_palette_entry_modifier' declared here
  class etc1_global_palette_entry_modifier
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:17,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h: In instantiation of 'void basisu::clear_obj(T&) [with T = basist::etc1_selector_palette_entry]':
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu_global_selector_palette.h:117:27:   required from here
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h:122:62: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct basist::etc1_selector_palette_entry'; use assignment or value-initialization instead [-Wclass-memaccess]
  template <typename T> inline void clear_obj(T& obj) { memset(&obj, 0, sizeof(obj)); }
                                                        ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:20,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu_global_selector_palette.h:108:9: note: 'struct basist::etc1_selector_palette_entry' declared here
  struct etc1_selector_palette_entry
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:17,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h: In instantiation of 'void basisu::clear_obj(T&) [with T = basisu::pixel_block]':
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_global_selector_palette_helpers.h:37:33:   required from here
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h:122:62: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct basisu::pixel_block'; use assignment or value-initialization instead [-Wclass-memaccess]
  template <typename T> inline void clear_obj(T& obj) { memset(&obj, 0, sizeof(obj)); }
                                                        ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_frontend.h:19,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:21,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_global_selector_palette_helpers.h:27:9: note: 'struct basisu::pixel_block' declared here
  struct pixel_block
         ^~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:17,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h: In instantiation of 'void basisu::clear_obj(T&) [with T = basisu::etc1_endpoint_palette_entry]':
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:68:19:   required from here
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h:122:62: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct basisu::etc1_endpoint_palette_entry'; use assignment or value-initialization instead [-Wclass-memaccess]
  template <typename T> inline void clear_obj(T& obj) { memset(&obj, 0, sizeof(obj)); }
                                                        ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:55:9: note: 'struct basisu::etc1_endpoint_palette_entry' declared here
  struct etc1_endpoint_palette_entry
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:17,
                 from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h: In instantiation of 'void basisu::clear_obj(T&) [with T = basisu::basisu_backend_slice_desc]':
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:116:19:   required from here
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/transcoder/basisu.h:122:62: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct basisu::basisu_backend_slice_desc'; use assignment or value-initialization instead [-Wclass-memaccess]
  template <typename T> inline void clear_obj(T& obj) { memset(&obj, 0, sizeof(obj)); }
                                                        ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.cpp:18:
/home/akien/Projects/godot/godot.git/thirdparty/bu.git/basisu_backend.h:108:9: note: 'struct basisu::basisu_backend_slice_desc' declared here
  struct basisu_backend_slice_desc
         ^~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/basisu.dir/build.make:63: CMakeFiles/basisu.dir/basisu_backend.cpp.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/basisu.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```