### PR TITLE
Proposal: add an ability to Y-flip images during transcode

### DIFF
--- a/transcoder/basisu_transcoder.h
+++ b/transcoder/basisu_transcoder.h
@@ -139,7 +139,7 @@ namespace basist
 		bool decode_tables(const uint8_t *pTable_data, uint32_t table_data_size);
 
 		bool transcode_slice(void *pDst_blocks, uint32_t num_blocks_x, uint32_t num_blocks_y, const uint8_t *pImage_data, uint32_t image_data_size, block_format fmt, 
-			uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const basis_file_header &header, const basis_slice_desc& slice_desc, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
+			int32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const basis_file_header &header, const basis_slice_desc& slice_desc, int32_t output_row_pitch_in_blocks_or_pixels,
 			basisu_transcoder_state *pState = nullptr, bool astc_transcode_alpha = false, void* pAlpha_blocks = nullptr, uint32_t output_rows_in_pixels = 0);
 
 	private:
@@ -317,7 +317,11 @@ namespace basist
 
 			// The output buffer contains alpha endpoint/selector indices. 
 			// Used internally when decoding formats like ASTC that require both color and alpha data to be available when transcoding to the output format.
-			cDecodeFlagsOutputHasAlphaIndices = 16
+			cDecodeFlagsOutputHasAlphaIndices = 16,
+
+			// Flip Y axis during decode, unless the file was already generated
+			// with the m_y_flipped flag set
+			cDecodeFlagsFlipY = 32,
 		};
 								
 		// transcode_image_level() decodes a single mipmap level from the .basis file to any of the supported output texture formats.


### PR DESCRIPTION
While the encoder-provided option to flip the image during encoding is everything needed when one controls the whole pipeline, it's of no use for general image viewers that have no power over how the input was generated. Having the chance to configure Y flipping during the transcode makes it easier to integrate, as the application doesn't need to worry about patching texture coordinates or doing texture coordinate transform in a shader.

While flipping the compressed image post-transcode is possible, it's a non-trivial amount of work, considering the broad range of target formats supported. On the other hand, when done directly in Basis, flipping can be done on the internal ETC1S representation:

1.  patching the output pointer and making row stride negative, which has very little impact on existing code (apart from making pointer arithmetic work with signed types);
2.  and bit-flipping the selector bits using a modified [3-operation bit reverse trick](http://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64BitsDiv).

Assuming the encoder's output is reasonably invariant to image flip, this new code path could be tested by comparing these two outputs for equality:

-   flipped PNG -> basis -> target format -> RGBA
-   PNG -> basis -> flipped target format -> RGBA

This was tested on ETC1/2, BC1-7, ASTC and RGBA8 output, **however it currently doesn't handle flipping for PVRTC textures**, as there's cross-block modulation and I don't have deep enough understanding of the format to be able to code that. Similarly for FXT1 due to a different block size. Treat the code more like a proof-of-concept (and feel free to do anything with it, of course).

- - -

At first I thought about just opening a feature request, but then went on to try how feasible this would be, to avoid asking for the impossible :) It's of course entirely possible that I missed some important aspect of the format and it *can't* work this way -- however if it can, I dare to say the code changes needed won't be so invasive and the additional maintenance/testing effort for this feature is in reasonable bounds.