### PR TITLE
Don't require the huge BC7m6 tables if this format is disabled

### DIFF
--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -146,7 +146,9 @@ namespace basisu
 
 namespace basist
 {
+#if BASISD_SUPPORT_BC7_MODE6_OPAQUE_ONLY
 #include "basisu_transcoder_tables_bc7_m6.inc"
+#endif
 
 #if BASISD_ENABLE_DEBUG_FLAGS
 	static uint32_t g_debug_flags = 0;


### PR DESCRIPTION
A rather trivial change -- the 1.3 MB file might be considered excessive when bundling the transcoder sources in another project, don't require it to be present when not needed.