### PR TITLE
Don't append .basis extension in basisu_comp.cpp

### DIFF
--- a/basisu_comp.cpp
+++ b/basisu_comp.cpp
@@ -1066,9 +1066,7 @@ namespace basisu
 		{
 			const uint8_vec &comp_data = m_basis_file.get_compressed_data();
 
-			std::string basis_filename(m_params.m_out_filename);
-			string_remove_extension(basis_filename);
-			basis_filename += ".basis";
+			const std::string& basis_filename = m_params.m_out_filename;
 
 			if (!write_vec_to_file(basis_filename.c_str(), comp_data))
 			{


### PR DESCRIPTION
This is normally redundant - basisu_tool.cpp already computes the output
filename with .basis extension. However, this makes it so that if you
use -output_file command with filename without extension (for example,
one generated by mkstemp), it writes the specified filename instead of
the file with .basis appended.