### PR TITLE
Added -renorm flag

### DIFF
--- a/basisu_comp.cpp
+++ b/basisu_comp.cpp
@@ -96,6 +96,14 @@ namespace basisu
 			debug_printf("m_tex_type: %u\n", m_params.m_tex_type);
 			debug_printf("m_userdata0: 0x%X, m_userdata1: 0x%X\n", m_params.m_userdata0, m_params.m_userdata1);
 			debug_printf("m_us_per_frame: %i (%f fps)\n", m_params.m_us_per_frame, m_params.m_us_per_frame ? 1.0f / (m_params.m_us_per_frame / 1000000.0f) : 0);
+
+			PRINT_BOOL_VALUE(m_renormalize);
+
+			debug_printf("swizzle: %d,%d,%d,%d\n",
+				m_params.m_swizzle[0],
+				m_params.m_swizzle[1],
+				m_params.m_swizzle[2],
+				m_params.m_swizzle[3]);
 						
 #undef PRINT_BOOL_VALUE
 #undef PRINT_INT_VALUE
@@ -283,6 +291,17 @@ namespace basisu
 			}
 
 			if (m_params.m_seperate_rg_to_color_alpha)
+			// normalize source image
+			if (m_params.m_renormalize)
+			{
+				file_image.renormalize_normal_map();
+			}
+
+			bool alpha_swizzled = false;
+			if (m_params.m_swizzle[0] != 0 ||
+				m_params.m_swizzle[1] != 1 ||
+				m_params.m_swizzle[2] != 2 ||
+				m_params.m_swizzle[3] != 3)
 			{
 				// Used for XY normal maps in RG - puts X in color, Y in alpha
 				for (uint32_t y = 0; y < file_image.get_height(); y++)

--- a/basisu_comp.cpp
+++ b/basisu_comp.cpp
@@ -98,12 +98,6 @@ namespace basisu
 			debug_printf("m_us_per_frame: %i (%f fps)\n", m_params.m_us_per_frame, m_params.m_us_per_frame ? 1.0f / (m_params.m_us_per_frame / 1000000.0f) : 0);
 
 			PRINT_BOOL_VALUE(m_renormalize);
-
-			debug_printf("swizzle: %d,%d,%d,%d\n",
-				m_params.m_swizzle[0],
-				m_params.m_swizzle[1],
-				m_params.m_swizzle[2],
-				m_params.m_swizzle[3]);
 						
 #undef PRINT_BOOL_VALUE
 #undef PRINT_INT_VALUE
@@ -290,18 +284,13 @@ namespace basisu
 				file_image = m_params.m_source_images[source_file_index];
 			}
 
-			if (m_params.m_seperate_rg_to_color_alpha)
 			// normalize source image
 			if (m_params.m_renormalize)
 			{
 				file_image.renormalize_normal_map();
 			}
 
-			bool alpha_swizzled = false;
-			if (m_params.m_swizzle[0] != 0 ||
-				m_params.m_swizzle[1] != 1 ||
-				m_params.m_swizzle[2] != 2 ||
-				m_params.m_swizzle[3] != 3)
+			if (m_params.m_seperate_rg_to_color_alpha)
 			{
 				// Used for XY normal maps in RG - puts X in color, Y in alpha
 				for (uint32_t y = 0; y < file_image.get_height(); y++)

--- a/basisu_comp.h
+++ b/basisu_comp.h
@@ -221,10 +221,6 @@ namespace basisu
 			m_multithreading.clear();
 			m_seperate_rg_to_color_alpha.clear();
 			m_renormalize.clear();
-			m_swizzle[0] = 0;
-			m_swizzle[1] = 1;
-			m_swizzle[2] = 2;
-			m_swizzle[3] = 3;
 			m_hybrid_sel_cb_quality_thresh.clear();
 			m_global_pal_bits.clear();
 			m_global_mod_bits.clear();
@@ -319,9 +315,6 @@ namespace basisu
 		bool_param<false> m_seperate_rg_to_color_alpha;
 
 		bool_param<false> m_renormalize;
-
-		// Swizzle incoming channels
-		char m_swizzle[4];
 
 		bool_param<false> m_disable_hierarchical_endpoint_codebooks;
 

--- a/basisu_comp.h
+++ b/basisu_comp.h
@@ -220,6 +220,11 @@ namespace basisu
 			m_force_alpha.clear();
 			m_multithreading.clear();
 			m_seperate_rg_to_color_alpha.clear();
+			m_renormalize.clear();
+			m_swizzle[0] = 0;
+			m_swizzle[1] = 1;
+			m_swizzle[2] = 2;
+			m_swizzle[3] = 3;
 			m_hybrid_sel_cb_quality_thresh.clear();
 			m_global_pal_bits.clear();
 			m_global_mod_bits.clear();
@@ -312,6 +317,11 @@ namespace basisu
 		
 		// Split the R channel to RGB and the G channel to alpha, then write a basis file with alpha channels
 		bool_param<false> m_seperate_rg_to_color_alpha;
+
+		bool_param<false> m_renormalize;
+
+		// Swizzle incoming channels
+		char m_swizzle[4];
 
 		bool_param<false> m_disable_hierarchical_endpoint_codebooks;
 

--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -361,33 +361,6 @@ public:
 			{
 				m_comp_params.m_renormalize = true;
 			}
-			else if (strcasecmp(pArg, "-swizzle") == 0)
-			{
-				REMAINING_ARGS_CHECK(1);
-				const char *swizzle = arg_v[arg_index + 1];
-				if (strlen(swizzle) != 4)
-				{
-					error_printf("Swizzle requires exactly 4 characters\n");
-					return false;
-				}
-				for (int i=0; i<4; ++i)
-				{
-					if (swizzle[i] == 'r')
-						m_comp_params.m_swizzle[i] = 0;
-					else if (swizzle[i] == 'g')
-						m_comp_params.m_swizzle[i] = 1;
-					else if (swizzle[i] == 'b')
-						m_comp_params.m_swizzle[i] = 2;
-					else if (swizzle[i] == 'a')
-						m_comp_params.m_swizzle[i] = 3;
-					else
-					{
-						error_printf("Swizzle must be one of [rgba]");
-						return false;
-					}
-				}
-				arg_count++;
-			}
 			else if (strcasecmp(pArg, "-no_multithreading") == 0)
 			{
 				m_comp_params.m_multithreading = false;

--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -82,6 +82,7 @@ static void print_usage()
 		" -max_selectors X: Manually set the max number of color selector clusters from 1-16128, use instead of -q\n"
 		" -y_flip: Flip input images vertically before compression\n"
 		" -normal_map: Tunes codec parameters for better quality on normal maps (linear colorspace metrics, linear mipmap filtering, no selector RDO, no sRGB)\n"
+		" -renorm: Renormalize the input image before compression\n"
 		" -no_alpha: Always output non-alpha basis files, even if one or more inputs has alpha\n"
 		" -force_alpha: Always output alpha basis files, even if no inputs has alpha\n"
 		" -separate_rg_to_color_alpha: Separate input R and G channels to RGB and A (for tangent space XY normal maps)\n"
@@ -356,6 +357,37 @@ public:
 			else if ((strcasecmp(pArg, "-separate_rg_to_color_alpha") == 0) ||
 			        (strcasecmp(pArg, "-seperate_rg_to_color_alpha") == 0)) // was mispelled for a while - whoops!
 				m_comp_params.m_seperate_rg_to_color_alpha = true;
+			else if (strcasecmp(pArg, "-renorm") == 0)
+			{
+				m_comp_params.m_renormalize = true;
+			}
+			else if (strcasecmp(pArg, "-swizzle") == 0)
+			{
+				REMAINING_ARGS_CHECK(1);
+				const char *swizzle = arg_v[arg_index + 1];
+				if (strlen(swizzle) != 4)
+				{
+					error_printf("Swizzle requires exactly 4 characters\n");
+					return false;
+				}
+				for (int i=0; i<4; ++i)
+				{
+					if (swizzle[i] == 'r')
+						m_comp_params.m_swizzle[i] = 0;
+					else if (swizzle[i] == 'g')
+						m_comp_params.m_swizzle[i] = 1;
+					else if (swizzle[i] == 'b')
+						m_comp_params.m_swizzle[i] = 2;
+					else if (swizzle[i] == 'a')
+						m_comp_params.m_swizzle[i] = 3;
+					else
+					{
+						error_printf("Swizzle must be one of [rgba]");
+						return false;
+					}
+				}
+				arg_count++;
+			}
 			else if (strcasecmp(pArg, "-no_multithreading") == 0)
 			{
 				m_comp_params.m_multithreading = false;


### PR DESCRIPTION
It is sometimes useful to renormalize the top level image when compressing normal maps. This PR adds the flag -renorm to do just that.