### PR TITLE
Optimize ETC1 selector palette matching

### DIFF
--- a/basisu_backend.cpp
+++ b/basisu_backend.cpp
@@ -901,6 +901,20 @@ namespace basisu
 							const float selector_remap_thresh = maximum(1.0f, m_params.m_selector_rdo_quality_thresh); //2.5f;
 							const bool use_strict_search = (m_params.m_compression_level == 0) && (selector_remap_thresh == 1.0f);
 
+							// selector_trials[s] represents the color block decoded assuming all selectors are equal to s
+							// this allows us to efficiently evaluate each pixel for any selector in the loop below without
+							// having to decode the entire block every time
+							color_rgba selector_trials[4][16];
+
+							if (!use_strict_search)
+							{
+								for (uint32_t s = 0; s < 4; ++s)
+								{
+									etc_blk.set_all_selectors(s);
+									unpack_etc1(etc_blk, selector_trials[s]);
+								}
+							}
+
 							for (uint32_t j = 0; j < selector_history_buf.size(); j++)
 							{
 								const int trial_idx = selector_history_buf[j];
@@ -917,18 +931,16 @@ namespace basisu
 								}
 								else
 								{
-									for (uint32_t sy = 0; sy < 4; sy++)
-										for (uint32_t sx = 0; sx < 4; sx++)
-											etc_blk.set_selector(sx, sy, m_selector_palette[m_selector_remap_table_new_to_old[trial_idx]](sx, sy));
-
-									// TODO: Optimize this
-									unpack_etc1(etc_blk, etc_blk_unpacked);
+									const basist::etc1_selector_palette_entry& sel = m_selector_palette[m_selector_remap_table_new_to_old[trial_idx]];
 
 									uint64_t trial_err = 0;
 									const uint64_t thresh_err = minimum((uint64_t)ceilf(cur_err * selector_remap_thresh), best_trial_err);
 									for (uint32_t p = 0; p < 16; p++)
 									{
-										trial_err += color_distance(r.get_params().m_perceptual, src_pixels.get_ptr()[p], etc_blk_unpacked[p], false);
+										// the color of pixel p, assuming the relevant selector is set to sel[p] - this effectively simulates decoding with sel
+										const color_rgba& selp = selector_trials[sel[p]][p];
+
+										trial_err += color_distance(r.get_params().m_perceptual, src_pixels.get_ptr()[p], selp, false);
 										if (trial_err > thresh_err)
 											break;
 									}

--- a/basisu_etc.h
+++ b/basisu_etc.h
@@ -287,6 +287,20 @@ namespace basisu
 			p[-2] |= (msb << byte_bit_ofs);
 		}
 
+		// Selector "val" ranges from 0-3 and is a direct index into g_etc1_inten_tables.
+		inline void set_all_selectors(uint32_t val)
+		{
+			assert(val < 4);
+
+			const uint32_t etc1_val = g_selector_index_to_etc1[val];
+
+			const uint32_t lsb = etc1_val & 1;
+			const uint32_t msb = etc1_val >> 1;
+
+			m_bytes[4] = m_bytes[5] = msb ? 0xff : 0;
+			m_bytes[6] = m_bytes[7] = lsb ? 0xff : 0;
+		}
+
 		inline uint32_t get_raw_selector_bits() const
 		{
 			return m_bytes[4] | (m_bytes[5] << 8) | (m_bytes[6] << 16) | (m_bytes[7] << 24);


### PR DESCRIPTION
Right now when compression level isn't 0, we take each 4x4 block and try
to replace the selector indices with one of the 64 entries in the
palette. If we find a resulting selector block that has a low enough
error, we use that instead.

The way the code is implemented right now, we decode each block from
scratch for each entry, which means we decode each pixel 64 times.

However, each pixel's decoded result only depends on the endpoints (that
are static) and on the selector in that pixel (which has only 4 possible
values), so for each pixel we need at most 4 decodes.

This change switches the code around so that we pre-decode all 4
variants of the entire block ahead of time, and then just index into
this when evaluating matches.

We additionally cache the errors to make sure we don't just decode each
pixel 4 times, but also evaluate color distances only 4 times - previously we evaluated
each pixel's distance up to 64 times.

This results in bit-identical images since we look at the exact same
data, but the encoding is faster - on a 2Kx2K PNG on a Core i7-8700K,
these two changes reduce the encoding time including a full mip chain from
8.5 seconds to 6.6 seconds.