### PR TITLE
Include <ostream> in basisu_enc.h

### DIFF
--- a/basisu_enc.h
+++ b/basisu_enc.h
@@ -22,6 +22,7 @@
 #include <functional>
 #include <thread>
 #include <unordered_map>
+#include <ostream>
 
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <libgen.h>


### PR DESCRIPTION
In a future version of MSVC, \<string\> doesn't transitively include\<ostream\>.
This port will compile failed with error C3861: 'tolower': identifier not found, so I add include\<ostream\> into the header file.



