### PR TITLE
Ignoring VS working files and Mac finder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
 bin/
 build/
+
+# VS project and working files
+*.vcxproj.user
+.vs/
+Debug/
+Release/
+
+
+# Mac finder
+.DS_Store


### PR DESCRIPTION
Minor change but stops the need to keep manually ignoring/reverting working files in Git. No functional changes.