### PR TITLE
Resolve unreachable code warnings

### DIFF
--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -10053,7 +10053,7 @@ namespace basist
 #if !BASISD_SUPPORT_DXT1
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: DXT1 unsupported\n");
 				return false;
-#endif
+#else
 				uint32_t slice_index_to_decode = slice_index;
 				// If the caller wants us to transcode the mip level's alpha data, then use the next slice.
 				if ((basis_file_has_alpha_slices) && (transcode_alpha_data_to_opaque_formats))
@@ -10065,13 +10065,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to BC1 failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFBC4_R:
 			{
 #if !BASISD_SUPPORT_DXT5A
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: DXT5A unsupported\n");
 				return false;
-#endif
+#else
 				uint32_t slice_index_to_decode = slice_index;
 				// If the caller wants us to transcode the mip level's alpha data, then use the next slice.
 				if ((basis_file_has_alpha_slices) && (transcode_alpha_data_to_opaque_formats))
@@ -10083,13 +10084,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to BC4 failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFPVRTC1_4_RGB:
 			{
 #if !BASISD_SUPPORT_PVRTC1
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: PVRTC1 unsupported\n");
 				return false;
-#endif
+#else
 				uint32_t slice_index_to_decode = slice_index;
 				// If the caller wants us to transcode the mip level's alpha data, then use the next slice.
 				if ((basis_file_has_alpha_slices) && (transcode_alpha_data_to_opaque_formats))
@@ -10102,13 +10104,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to PVRTC1 4 RGB failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFPVRTC1_4_RGBA:
 			{
 #if !BASISD_SUPPORT_PVRTC1
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: PVRTC1 unsupported\n");
 				return false;
-#endif
+#else
 				assert(basis_file_has_alpha_slices);
 
 				// Temp buffer to hold alpha block endpoint/selector indices
@@ -10131,6 +10134,7 @@ namespace basist
 				}
 
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFBC7_RGBA:
 			case transcoder_texture_format::cTFBC7_ALT:
@@ -10164,7 +10168,7 @@ namespace basist
 #if !BASISD_SUPPORT_ETC2_EAC_A8
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: ETC2 EAC A8 unsupported\n");
 				return false;
-#endif
+#else
 				assert(bytes_per_block_or_pixel == 16);
 
 				if (basis_file_has_alpha_slices)
@@ -10192,17 +10196,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to ETC2 A failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFBC3_RGBA:
 			{
-#if !BASISD_SUPPORT_DXT1
-            BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: DXT1 unsupported\n");
+#if !BASISD_SUPPORT_DXT1 || !BASISD_SUPPORT_DXT5A
+            BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: DXT1 and DXT5A unsupported\n");
 				return false;
-#endif
-#if !BASISD_SUPPORT_DXT5A
-            BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: DXT5A unsupported\n");
-				return false;
-#endif
+#else
 				assert(bytes_per_block_or_pixel == 16);
 
 				// First decode the alpha data 
@@ -10231,13 +10232,14 @@ namespace basist
 				}
 
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFBC5_RG:
 			{
 #if !BASISD_SUPPORT_DXT5A
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: DXT5A unsupported\n");
 				return false;
-#endif
+#else
 				assert(bytes_per_block_or_pixel == 16);
 
 				// Decode the R data (actually the green channel of the color data slice in the basis file)
@@ -10264,13 +10266,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to BC5 channel 0 failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFASTC_4x4_RGBA:
 			{
 #if !BASISD_SUPPORT_ASTC
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: ASTC unsupported\n");
 				return false;
-#endif
+#else
 				assert(bytes_per_block_or_pixel == 16);
 
 				if (basis_file_has_alpha_slices)
@@ -10293,13 +10296,14 @@ namespace basist
             }
 
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFATC_RGB:
 			{
 #if !BASISD_SUPPORT_ATC
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: ATC unsupported\n");
 				return false;
-#endif
+#else
 				uint32_t slice_index_to_decode = slice_index;
 				// If the caller wants us to transcode the mip level's alpha data, then use the next slice.
 				if ((basis_file_has_alpha_slices) && (transcode_alpha_data_to_opaque_formats))
@@ -10311,17 +10315,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to ATC_RGB failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFATC_RGBA:
 			{
 #if !BASISD_SUPPORT_ATC
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: ATC unsupported\n");
 				return false;
-#endif
-#if !BASISD_SUPPORT_DXT5A
-            BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: DXT5A unsupported\n");
-   			return false;
-#endif
+#else
 				assert(bytes_per_block_or_pixel == 16);
 
 				// First decode the alpha data 
@@ -10348,13 +10349,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to ATC A failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFPVRTC2_4_RGB:
 			{
 #if !BASISD_SUPPORT_PVRTC2
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: PVRTC2 unsupported\n");
 				return false;
-#endif
+#else
 				uint32_t slice_index_to_decode = slice_index;
 				// If the caller wants us to transcode the mip level's alpha data, then use the next slice.
 				if ((basis_file_has_alpha_slices) && (transcode_alpha_data_to_opaque_formats))
@@ -10366,13 +10368,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to cPVRTC2_4_RGB failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFPVRTC2_4_RGBA:
 			{
 #if !BASISD_SUPPORT_PVRTC2
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: PVRTC2 unsupported\n");
 				return false;
-#endif
+#else
 				if (basis_file_has_alpha_slices)
 				{
 					// First decode the alpha data to the output (we're using the output texture as a temp buffer here).
@@ -10396,6 +10399,7 @@ namespace basist
 				}
 
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFRGBA32:
 			{
@@ -10470,7 +10474,7 @@ namespace basist
 #if !BASISD_SUPPORT_FXT1
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: FXT1 unsupported\n");
 				return false;
-#endif
+#else
 				uint32_t slice_index_to_decode = slice_index;
 				// If the caller wants us to transcode the mip level's alpha data, then use the next slice.
 				if ((basis_file_has_alpha_slices) && (transcode_alpha_data_to_opaque_formats))
@@ -10482,13 +10486,14 @@ namespace basist
 					BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: transcode_slice() to FXT1_RGB failed\n");
 				}
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFETC2_EAC_R11:
 			{
 #if !BASISD_SUPPORT_ETC2_EAC_RG11
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: EAC_RG11 unsupported\n");
 				return false;
-#endif
+#else
 				uint32_t slice_index_to_decode = slice_index;
 				// If the caller wants us to transcode the mip level's alpha data, then use the next slice.
 				if ((basis_file_has_alpha_slices) && (transcode_alpha_data_to_opaque_formats))
@@ -10501,13 +10506,14 @@ namespace basist
 				}
 
 				break;
+#endif
 			}
 			case transcoder_texture_format::cTFETC2_EAC_RG11:
 			{
 #if !BASISD_SUPPORT_ETC2_EAC_RG11
             BASISU_DEVEL_ERROR("basisu_transcoder::transcode_image_level: EAC_RG11 unsupported\n");
 				return false;
-#endif
+#else
 				assert(bytes_per_block_or_pixel == 16);
 
 				if (basis_file_has_alpha_slices)
@@ -10536,6 +10542,7 @@ namespace basist
 				}
 
 				break;
+#endif
 			}
 			default:
 			{


### PR DESCRIPTION
When building without some of the transcode format options unreachable code warnings are generated, e.g.: `warning C4702: unreachable code` (in VS). This PR doesn't change anything functionally other than removing warnings. To reproduce the warnings, simply define any of these:
```
#define BASISD_SUPPORT_ETC2_EAC_RG11 0
#define BASISD_SUPPORT_PVRTC1 0
#define BASISD_SUPPORT_PVRTC2 0
#define BASISD_SUPPORT_ATC 0
#define BASISD_SUPPORT_ASTC 0
#define BASISD_SUPPORT_ETC2_EAC_A8 0
#define BASISD_SUPPORT_DXT5A 0
#define BASISD_SUPPORT_DXT1 0
```
Building the transcoder was tested disabling each one of the options.