### PR TITLE
Fixed undefined behavior in BASISU_OFFSETOF

### DIFF
--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -88,7 +88,7 @@
 #define BASISU_ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 #define BASISU_NO_EQUALS_OR_COPY_CONSTRUCT(x) x(const x &) = delete; x& operator= (const x &) = delete;
 #define BASISU_ASSUME(x) static_assert(x, #x);
-#define BASISU_OFFSETOF(s, m) (uint32_t)(intptr_t)(&((s *)(0))->m)
+#define BASISU_OFFSETOF(s, m) offsetof(s, m)
 #define BASISU_STRINGIZE(x) #x
 #define BASISU_STRINGIZE2(x) BASISU_STRINGIZE(x)
 


### PR DESCRIPTION
The original implementation was dereferencing a nullptr which is an undefined behavior according to the C++ spec. It was triggering some automatic errors during our sanitizer tests (asan with nullptr check).

The fix replaces the offset with standard implementation of offsetof that uses compiler built in instructions when available (avoiding the undefined behavior).