### PR TITLE
Fixes for building with MSVC 32-bit targets

### DIFF
--- a/basisu_enc.cpp
+++ b/basisu_enc.cpp
@@ -24,7 +24,9 @@
 
 #if defined(_WIN32)
 // For QueryPerformanceCounter/QueryPerformanceFrequency
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #define NOMINMAX
 #include <windows.h>
 #endif
@@ -390,7 +392,7 @@ namespace basisu
 			bool has_alpha = img.has_alpha();
 			if ((!has_alpha) || ((image_save_flags & cImageSaveIgnoreAlpha) != 0))
 			{
-				const uint64_t total_bytes = (uint64_t)img.get_width() * 3U * (uint64_t)img.get_height();
+				const uint8_vec::size_type total_bytes = uint8_vec::size_type(3) * img.get_width() * img.get_height();
 				uint8_vec rgb_pixels(total_bytes);
 				uint8_t *pDst = &rgb_pixels[0];
 								
@@ -1830,7 +1832,7 @@ namespace basisu
 
 				} while (pixels_remaining);
 
-				assert((pDst - &input_line_buf[0]) == width * tga_bytes_per_pixel);
+				assert((pDst - &input_line_buf[0]) == (std::ptrdiff_t)(width * tga_bytes_per_pixel));
 
 				pLine_data = &input_line_buf[0];
 			}

--- a/basisu_uastc_enc.cpp
+++ b/basisu_uastc_enc.cpp
@@ -3761,7 +3761,7 @@ namespace basisu
 	{
 		std::size_t operator()(selector_bitsequence const& s) const noexcept
 		{
-			return hash_hsieh((uint8_t *)&s, sizeof(s)) ^ s.m_sel;
+			return hash_hsieh((uint8_t *)&s, sizeof(s)) ^ (std::size_t)s.m_sel;
 		}
 	};
 		


### PR DESCRIPTION
When building as a lib with out-of-the-box MSVC settings these minor tweaks fix a few warnings (which otherwise break the build with `/W4`).

- The `WIN32_LEAN_AND_MEAN` guard is minor.
- Creating `rgb_pixels` with a `size_type` has no side effect on 64-bit systems but limits the image size on 32-bit systems (but the maximum requires more memory than a 32-bit system can address anyway).
- The only worry is `selector_bitsequence_hash`, since `size_t` is now 32-bit but the xor'd selector bits are 64. This change makes it compile but doesn't go further.