### PR TITLE
Xcode encoder warnings removed

### DIFF
--- a/apg_bmp.c
+++ b/apg_bmp.c
@@ -442,8 +442,8 @@ unsigned int apg_bmp_write( const char* filename, unsigned char* pixels_ptr, int
   if ( labs( w ) > _BMP_MAX_DIMS || labs( h ) > _BMP_MAX_DIMS ) { return 0; }
   if ( n_chans != 3 && n_chans != 4 ) { return 0; }
 
-  uint32_t height = labs( h );
-  uint32_t width  = labs( w );
+  uint32_t height = (uint32_t)labs( h );
+  uint32_t width  = (uint32_t)labs( w );
   // work out if any padding how much to skip at end of each row
   const size_t unpadded_row_sz      = width * n_chans;
   const size_t row_padding_sz       = 0 == unpadded_row_sz % 4 ? 0 : 4 - unpadded_row_sz % 4;

--- a/basisu_etc.cpp
+++ b/basisu_etc.cpp
@@ -138,7 +138,7 @@ namespace basisu
 						for (uint32_t packed_c = 0; packed_c < limit; packed_c++)
 						{
 							int v = etc1_decode_value(diff, inten, selector, packed_c);
-							uint32_t err = labs(v - static_cast<int>(color));
+							uint32_t err = (uint32_t)labs(v - static_cast<int>(color));
 							if (err < best_error)
 							{
 								best_error = err;

--- a/basisu_etc.h
+++ b/basisu_etc.h
@@ -116,7 +116,7 @@ namespace basisu
 		{
 			assert((ofs + num) <= 64U);
 			assert(num && (num < 32U));
-			return (read_be64(&m_uint64) >> ofs) & ((1UL << num) - 1UL);
+			return (uint32_t)(read_be64(&m_uint64) >> ofs) & ((1UL << num) - 1UL);
 		}
 
 		inline void set_general_bits(uint32_t ofs, uint32_t num, uint32_t bits)

--- a/jpgd.cpp
+++ b/jpgd.cpp
@@ -637,7 +637,7 @@ namespace jpgd {
 		}
 		if (!rv)
 		{
-			int capacity = JPGD_MAX(32768 - 256, (nSize + 2047) & ~2047);
+			int capacity = JPGD_MAX(32768 - 256, ((int)nSize + 2047) & ~2047);
 			mem_block* b = (mem_block*)jpgd_malloc(sizeof(mem_block) + capacity);
 			if (!b)
 			{


### PR DESCRIPTION
Following on from #134 this does the same for the encoder. Xcode by default enables the _shortening_ warning. There are no side effects from the changes.