### PR TITLE
Add container independent image transcoders.

### DIFF
--- a/apg_bmp.c
+++ b/apg_bmp.c
@@ -442,8 +442,8 @@ unsigned int apg_bmp_write( const char* filename, unsigned char* pixels_ptr, int
   if ( labs( w ) > _BMP_MAX_DIMS || labs( h ) > _BMP_MAX_DIMS ) { return 0; }
   if ( n_chans != 3 && n_chans != 4 ) { return 0; }
 
-  uint32_t height = labs( h );
-  uint32_t width  = labs( w );
+  uint32_t height = (uint32_t)labs( h );
+  uint32_t width  = (uint32_t)labs( w );
   // work out if any padding how much to skip at end of each row
   const size_t unpadded_row_sz      = width * n_chans;
   const size_t row_padding_sz       = 0 == unpadded_row_sz % 4 ? 0 : 4 - unpadded_row_sz % 4;

--- a/basisu_astc_decomp.cpp
+++ b/basisu_astc_decomp.cpp
@@ -39,6 +39,12 @@
 #define DE_LENGTH_OF_ARRAY(x) (sizeof(x)/sizeof(x[0]))
 #define DE_UNREF(x) (void)x
 
+#if __GNUC__ || __clang__
+  #define DE_MAYBE_UNUSED __attribute__((unused))
+#else
+  #define DE_MAYBE_UNUSED
+#endif
+
 typedef uint8_t deUint8;
 typedef int8_t deInt8;
 typedef uint32_t deUint32;
@@ -52,12 +58,12 @@ typedef uint64_t deUint64;
 
 namespace basisu_astc
 {
-	static bool inBounds(int v, int l, int h)
+	static bool  DE_MAYBE_UNUSED inBounds(int v, int l, int h)
 	{
 		return (v >= l) && (v < h);
 	}
 
-	static bool inRange(int v, int l, int h)
+	static bool  DE_MAYBE_UNUSED inRange(int v, int l, int h)
 	{
 		return (v >= l) && (v <= h);
 	}
@@ -192,7 +198,7 @@ namespace basisu_astc
 		return (a + b - 1) / b;
 	}
 
-	static bool deInBounds32(uint32_t v, uint32_t l, uint32_t h)
+	static bool  DE_MAYBE_UNUSED deInBounds32(uint32_t v, uint32_t l, uint32_t h)
 	{
 		return (v >= l) && (v < h);
 	}

--- a/basisu_comp.cpp
+++ b/basisu_comp.cpp
@@ -626,14 +626,14 @@ namespace basisu
 			}
 		}
 
-		printf("Total basis file slices: %u\n", (uint32_t)m_slice_descs.size());
+		debug_printf("Total basis file slices: %u\n", (uint32_t)m_slice_descs.size());
 
 		for (uint32_t i = 0; i < m_slice_descs.size(); i++)
 		{
 			const basisu_backend_slice_desc &slice_desc = m_slice_descs[i];
 
-			printf("Slice: %u, alpha: %u, orig width/height: %ux%u, width/height: %ux%u, first_block: %u, image_index: %u, mip_level: %u, iframe: %u\n", 
-				i, slice_desc.m_alpha, slice_desc.m_orig_width, slice_desc.m_orig_height, slice_desc.m_width, slice_desc.m_height, slice_desc.m_first_block_index, slice_desc.m_source_file_index, slice_desc.m_mip_index, slice_desc.m_iframe);
+			debug_printf("Slice: %u, alpha: %u, orig width/height: %ux%u, width/height: %ux%u, first_block: %u, image_index: %u, mip_level: %u, iframe: %u\n",
+				i, slice_desc.m_alpha, slice_desc.m_orig_width, slice_desc.m_orig_height, slice_desc.m_width, slice_desc.m_height, slice_desc.m_first_block_index, slice_desc.m_source_file_index,      slice_desc.m_mip_index, slice_desc.m_iframe);
 
 			if (m_any_source_image_has_alpha)
 			{

--- a/basisu_enc.cpp
+++ b/basisu_enc.cpp
@@ -29,6 +29,14 @@
 #include <windows.h>
 #endif
 
+#ifdef max
+#undef max
+#endif
+
+#ifdef min
+#undef min
+#endif
+
 namespace basisu
 {
 	uint64_t interval_timer::g_init_ticks, interval_timer::g_freq;
@@ -1219,7 +1227,7 @@ namespace basisu
 		uint32_t max_count = 0, max_index = 0;
 		for (uint32_t i = 0; i < num_syms * num_syms; i++)
 			if (m_hist[i] > max_count)
-				max_count = m_hist[i], max_index = i;
+              static_cast<void>(max_count = m_hist[i]), max_index = i;
 
 		uint32_t a = max_index / num_syms, b = max_index % num_syms;
 
@@ -1655,7 +1663,7 @@ namespace basisu
 			return nullptr;
 		}
 
-		const uint32_t bytes_per_line = hdr.m_width * tga_bytes_per_pixel;
+		//const uint32_t bytes_per_line = hdr.m_width * tga_bytes_per_pixel;
 
 		const uint8_t *pSrc = pBuf + sizeof(tga_header);
 		uint32_t bytes_remaining = buf_size - sizeof(tga_header);

--- a/basisu_etc.cpp
+++ b/basisu_etc.cpp
@@ -138,7 +138,7 @@ namespace basisu
 						for (uint32_t packed_c = 0; packed_c < limit; packed_c++)
 						{
 							int v = etc1_decode_value(diff, inten, selector, packed_c);
-							uint32_t err = labs(v - static_cast<int>(color));
+							uint32_t err = (uint32_t)labs(v - static_cast<int>(color));
 							if (err < best_error)
 							{
 								best_error = err;

--- a/basisu_etc.h
+++ b/basisu_etc.h
@@ -116,7 +116,7 @@ namespace basisu
 		{
 			assert((ofs + num) <= 64U);
 			assert(num && (num < 32U));
-			return (read_be64(&m_uint64) >> ofs) & ((1UL << num) - 1UL);
+			return (uint32_t)((read_be64(&m_uint64) >> ofs) & ((1UL << num) - 1UL));
 		}
 
 		inline void set_general_bits(uint32_t ofs, uint32_t num, uint32_t bits)

--- a/basisu_frontend.cpp
+++ b/basisu_frontend.cpp
@@ -17,10 +17,15 @@
 // This code originally supported full ETC1 and ETC1S, so there's some legacy stuff to be cleaned up in here.
 // Add endpoint tiling support (where we force adjacent blocks to use the same endpoints during quantization), for a ~10% or more increase in bitrate at same SSIM. The backend already supports this.
 //
+#define _CRT_SECURE_NO_WARNINGS
 #include "transcoder/basisu.h"
 #include "basisu_frontend.h"
 #include <unordered_set>
 #include <unordered_map>
+
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
 
 #define BASISU_FRONTEND_VERIFY(c) do { if (!(c)) handle_verify_failure(__LINE__); } while(0)
 

--- a/basisu_miniz.h
+++ b/basisu_miniz.h
@@ -649,11 +649,11 @@ mz_ulong mz_adler32(mz_ulong adler, const unsigned char *ptr, size_t buf_len)
   if (!ptr) return MZ_ADLER32_INIT;
   while (buf_len) {
     for (i = 0; i + 7 < block_len; i += 8, ptr += 8) {
-      s1 += ptr[0], s2 += s1; s1 += ptr[1], s2 += s1; s1 += ptr[2], s2 += s1; s1 += ptr[3], s2 += s1;
-      s1 += ptr[4], s2 += s1; s1 += ptr[5], s2 += s1; s1 += ptr[6], s2 += s1; s1 += ptr[7], s2 += s1;
+      static_cast<void>(s1 += ptr[0]), s2 += s1; static_cast<void>(s1 += ptr[1]), s2 += s1; static_cast<void>(s1 += ptr[2]), s2 += s1; static_cast<void>(s1 += ptr[3]), s2 += s1;
+      static_cast<void>(s1 += ptr[4]), s2 += s1; static_cast<void>(s1 += ptr[5]), s2 += s1; static_cast<void>(s1 += ptr[6]), s2 += s1; static_cast<void>(s1 += ptr[7]), s2 += s1;
     }
-    for ( ; i < block_len; ++i) s1 += *ptr++, s2 += s1;
-    s1 %= 65521U, s2 %= 65521U; buf_len -= block_len; block_len = 5552;
+    for ( ; i < block_len; ++i) static_cast<void>(s1 += *ptr++), s2 += s1;
+    static_cast<void>(s1 %= 65521U), s2 %= 65521U; buf_len -= block_len; block_len = 5552;
   }
   return (s2 << 16) + s1;
 }
@@ -1179,7 +1179,7 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
         int tree_next, tree_cur; tinfl_huff_table *pTable;
         mz_uint i, j, used_syms, total, sym_index, next_code[17], total_syms[16]; pTable = &r->m_tables[r->m_type]; MZ_CLEAR_OBJ(total_syms); MZ_CLEAR_OBJ(pTable->m_look_up); MZ_CLEAR_OBJ(pTable->m_tree);
         for (i = 0; i < r->m_table_sizes[r->m_type]; ++i) total_syms[pTable->m_code_size[i]]++;
-        used_syms = 0, total = 0; next_code[0] = next_code[1] = 0;
+        static_cast<void>(used_syms = 0), total = 0; next_code[0] = next_code[1] = 0;
         for (i = 1; i <= 15; ++i) { used_syms += total_syms[i]; next_code[i + 1] = (total = ((total + total_syms[i]) << 1)); }
         if ((65536 != total) && (used_syms > 1))
         {
@@ -1355,11 +1355,11 @@ common_exit:
     {
       for (i = 0; i + 7 < block_len; i += 8, ptr += 8)
       {
-        s1 += ptr[0], s2 += s1; s1 += ptr[1], s2 += s1; s1 += ptr[2], s2 += s1; s1 += ptr[3], s2 += s1;
-        s1 += ptr[4], s2 += s1; s1 += ptr[5], s2 += s1; s1 += ptr[6], s2 += s1; s1 += ptr[7], s2 += s1;
+        static_cast<void>(s1 += ptr[0]), s2 += s1; static_cast<void>(s1 += ptr[1]), s2 += s1; static_cast<void>(s1 += ptr[2]), s2 += s1; static_cast<void>(s1 += ptr[3]), s2 += s1;
+        static_cast<void>(s1 += ptr[4]), s2 += s1; static_cast<void>(s1 += ptr[5]), s2 += s1; static_cast<void>(s1 += ptr[6]), s2 += s1; static_cast<void>(s1 += ptr[7]), s2 += s1;
       }
-      for ( ; i < block_len; ++i) s1 += *ptr++, s2 += s1;
-      s1 %= 65521U, s2 %= 65521U; buf_len -= block_len; block_len = 5552;
+      for ( ; i < block_len; ++i) static_cast<void>(s1 += *ptr++), s2 += s1;
+      static_cast<void>(s1 %= 65521U), s2 %= 65521U; buf_len -= block_len; block_len = 5552;
     }
     r->m_check_adler32 = (s2 << 16) + s1; if ((status == TINFL_STATUS_DONE) && (decomp_flags & TINFL_FLAG_PARSE_ZLIB_HEADER) && (r->m_check_adler32 != r->m_z_adler32)) status = TINFL_STATUS_ADLER32_MISMATCH;
   }
@@ -1862,7 +1862,7 @@ static int tdefl_flush_block(tdefl_compressor *d, int flush)
   if ( ((use_raw_block) || ((d->m_total_lz_bytes) && ((d->m_pOutput_buf - pSaved_output_buf + 1U) >= d->m_total_lz_bytes))) &&
        ((d->m_lookahead_pos - d->m_lz_code_buf_dict_pos) <= d->m_dict_size) )
   {
-    mz_uint i; d->m_pOutput_buf = pSaved_output_buf; d->m_bit_buffer = saved_bit_buf, d->m_bits_in = saved_bits_in;
+    mz_uint i; d->m_pOutput_buf = pSaved_output_buf; static_cast<void>(d->m_bit_buffer = saved_bit_buf), d->m_bits_in = saved_bits_in;
     TDEFL_PUT_BITS(0, 2);
     if (d->m_bits_in) { TDEFL_PUT_BITS(0, 8 - d->m_bits_in); }
     for (i = 2; i; --i, d->m_total_lz_bytes ^= 0xFFFF)
@@ -1877,7 +1877,7 @@ static int tdefl_flush_block(tdefl_compressor *d, int flush)
   // Check for the extremely unlikely (if not impossible) case of the compressed block not fitting into the output buffer when using dynamic codes.
   else if (!comp_block_succeeded)
   {
-    d->m_pOutput_buf = pSaved_output_buf; d->m_bit_buffer = saved_bit_buf, d->m_bits_in = saved_bits_in;
+    d->m_pOutput_buf = pSaved_output_buf; static_cast<void>(d->m_bit_buffer = saved_bit_buf), d->m_bits_in = saved_bits_in;
     tdefl_compress_block(d, MZ_TRUE);
   }
 

--- a/jpgd.cpp
+++ b/jpgd.cpp
@@ -637,7 +637,7 @@ namespace jpgd {
 		}
 		if (!rv)
 		{
-			int capacity = JPGD_MAX(32768 - 256, (nSize + 2047) & ~2047);
+			long capacity = JPGD_MAX(32768 - 256, (nSize + 2047) & ~2047);
 			mem_block* b = (mem_block*)jpgd_malloc(sizeof(mem_block) + capacity);
 			if (!b)
 			{

--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -86,7 +86,7 @@
 
 #define BASISU_NOTE_UNUSED(x) (void)(x)
 #define BASISU_ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
-#define BASISU_NO_EQUALS_OR_COPY_CONSTRUCT(x) x(const x &) = delete; x& operator= (const x &) = delete;
+#define BASISU_NO_EQUALS_OR_COPY_CONSTRUCT(x) x(const x &) = delete; x& operator= (const x &) = delete
 #define BASISU_ASSUME(x) static_assert(x, #x);
 #define BASISU_OFFSETOF(s, m) offsetof(s, m)
 #define BASISU_STRINGIZE(x) #x
@@ -293,7 +293,7 @@ namespace basisu
 	enum
 	{
 		cHuffmanMaxSupportedCodeSize = 16, cHuffmanMaxSupportedInternalCodeSize = 31, 
-		cHuffmanFastLookupBits = 10, 
+		cHuffmanFastLookupBits = 10,
 		cHuffmanMaxSymsLog2 = 14, cHuffmanMaxSyms = 1 << cHuffmanMaxSymsLog2,
 
 		// Small zero runs

--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -8923,12 +8923,13 @@ namespace basist
 		BASISU_NOTE_UNUSED(decode_flags);
 		BASISU_NOTE_UNUSED(channel0);
 		BASISU_NOTE_UNUSED(channel1);
+		BASISU_NOTE_UNUSED(orig_width);
+		BASISU_NOTE_UNUSED(orig_height);
 		BASISU_NOTE_UNUSED(output_rows_in_pixels);
 		BASISU_NOTE_UNUSED(output_row_pitch_in_blocks_or_pixels);
-		BASISU_NOTE_UNUSED(slice_desc);
-		BASISU_NOTE_UNUSED(header);
 		BASISU_NOTE_UNUSED(output_block_or_pixel_stride_in_bytes);
 		BASISU_NOTE_UNUSED(fmt);
+		BASISU_NOTE_UNUSED(has_alpha);
 		BASISU_NOTE_UNUSED(image_data_size);
 		BASISU_NOTE_UNUSED(pImage_data);
 		BASISU_NOTE_UNUSED(num_blocks_x);
@@ -10920,7 +10921,7 @@ namespace basist
 		case block_format::cETC2_EAC_RG11: return "ETC2_EAC_RG11";
 		default:
 			assert(0);
-			BASISU_DEVEL_ERROR("basis_get_block_format_name: Invalid fmt\n");
+			BASISU_DEVEL_ERROR("basis_get_basisu_texture_format: Invalid fmt\n");
 			break;
 		}
 		return "";

--- a/transcoder/basisu_transcoder.h
+++ b/transcoder/basisu_transcoder.h
@@ -107,6 +107,9 @@ namespace basist
 	// Returns format's name in ASCII
 	const char* basis_get_format_name(transcoder_texture_format fmt);
 
+    // Returns block format name in ASCII
+    const char* basis_get_block_format_name(block_format fmt);
+
 	// Returns true if the format supports an alpha channel.
 	bool basis_transcoder_format_has_alpha(transcoder_texture_format fmt);
 
@@ -164,8 +167,20 @@ namespace basist
 		bool decode_tables(const uint8_t *pTable_data, uint32_t table_data_size);
 
 		bool transcode_slice(void *pDst_blocks, uint32_t num_blocks_x, uint32_t num_blocks_y, const uint8_t *pImage_data, uint32_t image_data_size, block_format fmt, 
-			uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const basis_file_header &header, const basis_slice_desc& slice_desc, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
+			uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const bool is_video, const bool is_alpha_slice, const uint32_t miplevel, const uint32_t orig_width, const uint32_t orig_height, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
 			basisu_transcoder_state *pState = nullptr, bool astc_transcode_alpha = false, void* pAlpha_blocks = nullptr, uint32_t output_rows_in_pixels = 0);
+
+		bool transcode_slice(void *pDst_blocks, uint32_t num_blocks_x, uint32_t num_blocks_y, const uint8_t *pImage_data, uint32_t image_data_size, block_format fmt, 
+			uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const basis_file_header &header, const basis_slice_desc& slice_desc, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
+			basisu_transcoder_state *pState = nullptr, bool astc_transcode_alpha = false, void* pAlpha_blocks = nullptr, uint32_t output_rows_in_pixels = 0)
+		{
+			return transcode_slice(pDst_blocks, num_blocks_x, num_blocks_y, pImage_data, image_data_size, fmt, output_block_or_pixel_stride_in_bytes, bc1_allow_threecolor_blocks,
+                                   header.m_tex_type == cBASISTexTypeVideoFrames, (slice_desc.m_flags & cSliceDescFlagsHasAlpha) != 0, slice_desc.m_level_index,
+                                   slice_desc.m_orig_width, slice_desc.m_orig_height, output_row_pitch_in_blocks_or_pixels, pState,
+                                   astc_transcode_alpha,
+                                   pAlpha_blocks,
+                                   output_rows_in_pixels);
+        }
 
 		void clear()
 		{
@@ -194,7 +209,7 @@ namespace basist
 		basisu_transcoder_state m_def_state;
 	};
 
-	enum
+	enum basisu_decode_flags
 	{
 		// PVRTC1: decode non-pow2 ETC1S texture level to the next larger power of 2 (not implemented yet, but we're going to support it). Ignored if the slice's dimensions are already a power of 2.
 		cDecodeFlagsPVRTCDecodeToNextPow2 = 2,
@@ -221,10 +236,106 @@ namespace basist
 	public:
 		basisu_lowlevel_uastc_transcoder();
 
+        bool transcode_slice(void* pDst_blocks, uint32_t num_blocks_x, uint32_t num_blocks_y, const uint8_t* pImage_data, uint32_t image_data_size, block_format fmt,
+            uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, bool has_alpha, const uint32_t orig_width, const uint32_t orig_height, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
+            basisu_transcoder_state* pState = nullptr, uint32_t output_rows_in_pixels = 0, int channel0 = -1, int channel1 = -1, uint32_t decode_flags = 0);
+
 		bool transcode_slice(void* pDst_blocks, uint32_t num_blocks_x, uint32_t num_blocks_y, const uint8_t* pImage_data, uint32_t image_data_size, block_format fmt,
 			uint32_t output_block_or_pixel_stride_in_bytes, bool bc1_allow_threecolor_blocks, const basis_file_header& header, const basis_slice_desc& slice_desc, uint32_t output_row_pitch_in_blocks_or_pixels = 0,
-			basisu_transcoder_state* pState = nullptr, uint32_t output_rows_in_pixels = 0, int channel0 = -1, int channel1 = -1, uint32_t decode_flags = 0);
+			basisu_transcoder_state* pState = nullptr, uint32_t output_rows_in_pixels = 0, int channel0 = -1, int channel1 = -1, uint32_t decode_flags = 0)
+        {
+            return transcode_slice(pDst_blocks, num_blocks_x, num_blocks_y, pImage_data, image_data_size, fmt,
+                                   output_block_or_pixel_stride_in_bytes, bc1_allow_threecolor_blocks, (header.m_flags & cBASISHeaderFlagHasAlphaSlices) != 0, slice_desc.m_orig_width, slice_desc.m_orig_height, output_row_pitch_in_blocks_or_pixels,
+                                   pState, output_rows_in_pixels, channel0, channel1, decode_flags);
+        }
 	};
+
+    // Container independent image description.
+    struct basisu_image_desc {
+        uint32_t m_flags;
+        uint32_t m_rgb_byte_offset;
+        uint32_t m_rgb_byte_length;
+        uint32_t m_alpha_byte_offset;
+        uint32_t m_alpha_byte_length;
+        uint32_t m_orig_width;
+        uint32_t m_orig_height;
+        uint32_t m_num_blocks_x;
+        uint32_t m_num_blocks_y;
+        uint32_t m_level;
+
+        basisu_image_desc() {
+            memset(this, 0, sizeof(*this));
+        }
+
+        basisu_image_desc(basis_tex_format, uint32_t width, uint32_t height,
+                          uint32_t level)
+        {
+            memset(this, 0, sizeof(*this));
+            m_orig_width = width;
+            m_orig_height = height;
+            // Current formats are all 4 x 4 so ignore tex format param.
+            const uint32_t bw = 4, bh = 4;
+            m_num_blocks_x = (m_orig_width + (bw - 1)) / bw;
+            m_num_blocks_y = (m_orig_height + (bh - 1)) / bh;
+            m_level = level;
+        }
+
+        basisu_image_desc(const basis_slice_desc* pSlice_desc,
+                          const bool hasAlphaSlice,
+                          uint32_t level = 0) : m_level(level)
+        {
+            m_flags = pSlice_desc->m_flags & cSliceDescFlagsFrameIsIFrame;
+            m_rgb_byte_offset = pSlice_desc->m_file_ofs;
+            m_rgb_byte_length = pSlice_desc->m_file_size;
+            m_orig_width = pSlice_desc->m_orig_width;
+            m_orig_height = pSlice_desc->m_orig_height;
+            m_num_blocks_x = pSlice_desc->m_num_blocks_x;
+            m_num_blocks_y = pSlice_desc->m_num_blocks_y;
+            if (hasAlphaSlice) {
+                ++pSlice_desc;
+                m_alpha_byte_offset = pSlice_desc->m_file_ofs;
+                m_alpha_byte_length = pSlice_desc->m_file_size;
+            } else {
+                m_alpha_byte_offset = 0;
+                m_alpha_byte_length = 0;
+            }
+        }
+    };
+
+    // Container independent image transcoders.
+    class basisu_etc1s_image_transcoder : public basisu_lowlevel_etc1s_transcoder
+    {
+    public:
+        basisu_etc1s_image_transcoder(const basist::etc1_global_selector_codebook *pGsb)
+            : basisu_lowlevel_etc1s_transcoder(pGsb) { }
+
+        bool transcode_image(transcoder_texture_format targetFormat,
+                             uint8_t* dstBufferPtr,
+                             uint32_t dstBufferByteLength,
+                             const uint8_t* levelDataPtr,
+                             basisu_image_desc& imageDesc,
+                             uint32_t decodeFlags = 0,
+                             bool isVideo = false,
+                             uint32_t outputRowPitchInBlocksOrPixels = 0,
+                             basisu_transcoder_state* pState = nullptr,
+                             uint32_t outputRowsInPixels = 0);
+    };
+
+    class basisu_uastc_image_transcoder : public basisu_lowlevel_uastc_transcoder
+    {
+    public:
+        bool transcode_image(transcoder_texture_format targetFormat,
+                             uint8_t* dstBufferPtr,
+                             uint32_t dstBufferByteLength,
+                             const uint8_t* levelDataPtr,
+                             basisu_image_desc& imageDesc,
+                             uint32_t decode_flags = 0,
+                             bool hasAlpha = false,
+                             bool isVideo = false,
+                             uint32_t outputRowPitchInBlocksOrPixels = 0,
+                             basisu_transcoder_state* pState = nullptr,
+                             uint32_t outputRowsInPixels = 0);
+    };
 
 	struct basisu_slice_info
 	{
@@ -411,9 +522,13 @@ namespace basist
 			block_format fmt, uint32_t output_block_stride_in_bytes, uint32_t decode_flags = 0, uint32_t output_row_pitch_in_blocks_or_pixels = 0, basisu_transcoder_state * pState = nullptr, void* pAlpha_blocks = nullptr, 
 			uint32_t output_rows_in_pixels = 0, int channel0 = -1, int channel1 = -1) const;
 
+	   static void write_opaque_alpha_blocks(uint32_t num_blocks_x, uint32_t num_blocks_y,
+			void* pOutput_blocks, uint32_t output_blocks_buf_size_in_blocks, block_format fmt,
+			uint32_t block_stride_in_bytes, uint32_t output_row_pitch_in_blocks);
+
 	private:
-		mutable basisu_lowlevel_etc1s_transcoder m_lowlevel_etc1s_decoder;
-		mutable basisu_lowlevel_uastc_transcoder m_lowlevel_uastc_decoder;
+		mutable basisu_etc1s_image_transcoder m_etc1s_image_decoder;
+		mutable basisu_uastc_image_transcoder m_uastc_image_decoder;
 
 		bool m_ready_to_transcode;
 

--- a/webgl/transcoder/CMakeLists.txt
+++ b/webgl/transcoder/CMakeLists.txt
@@ -18,4 +18,18 @@ if (EMSCRIPTEN)
       OUTPUT_NAME "basis_transcoder"
       SUFFIX ".js"
       LINK_FLAGS "--bind -s ALLOW_MEMORY_GROWTH=1 -O3 -s ASSERTIONS=0 -s MALLOC=emmalloc -s MODULARIZE=1 -s EXPORT_NAME=BASIS ")
+
+  add_executable(msc_basis_transcoder.js
+    ../../transcoder/basisu_transcoder.cpp
+    image_transcoder_wrapper.cpp
+  )
+
+  target_compile_definitions(msc_basis_transcoder.js PRIVATE NDEBUG BASISD_SUPPORT_UASTC=1 BASISD_SUPPORT_BC7=0 BASISD_SUPPORT_ATC=0 BASISD_SUPPORT_ASTC_HIGHER_OPAQUE_QUALITY=0 BASISD_SUPPORT_PVRTC2=0 BASISD_SUPPORT_FXT1=0 BASISD_SUPPORT_ETC2_EAC_RG11=0)
+  target_compile_options(msc_basis_transcoder.js PRIVATE -O3)
+  target_include_directories(msc_basis_transcoder.js PRIVATE ../../transcoder)
+
+  set_target_properties(msc_basis_transcoder.js PROPERTIES
+      OUTPUT_NAME "msc_basis_transcoder"
+      SUFFIX ".js"
+      LINK_FLAGS "--bind -s ALLOW_MEMORY_GROWTH=1 -O3 -s ASSERTIONS=0 -s MALLOC=emmalloc -s MODULARIZE=1 -s EXPORT_NAME=MSC_TRANSCODER")
 endif()

--- a/webgl/transcoder/image_transcoder_wrapper.cpp
+++ b/webgl/transcoder/image_transcoder_wrapper.cpp
@@ -1,0 +1,719 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4 expandtab textwidth=80: */
+
+/*
+ * ©2019 Khronos Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <emscripten/bind.h>
+#include "basisu_transcoder.h"
+
+using namespace emscripten;
+using namespace basist;
+
+namespace msc {
+    // This is needed because the enum defining CDecode* is anonymous.
+    enum TranscodeFlagBits {
+        TranscodeAlphaDataToOpaqueFormats =
+               cDecodeFlagsTranscodeAlphaDataToOpaqueFormats,
+        HighQuality = cDecodeFlagsHighQuality
+    };
+
+    class BasisTranscoderState: public basisu_transcoder_state {
+    };
+
+    class TranscodedImage {
+      public:
+        TranscodedImage(size_t size) : image(size) { }
+
+        uint8_t* data() { return image.data(); }
+        size_t size() { return image.size(); }
+
+        val get_typed_memory_view() {
+           return val(typed_memory_view(image.size(), image.data()));
+        }
+
+      protected:
+        std::vector<uint8_t> image;
+    };
+
+    class ImageTranscoderHelper {
+        // block size calculations
+        static inline uint32_t getWidthInBlocks(uint32_t w, uint32_t bw)
+        {
+            return (w + (bw - 1)) / bw;
+        }
+
+        static inline uint32_t getHeightInBlocks(uint32_t h, uint32_t bh)
+        {
+            return (h + (bh - 1)) / bh;
+        }        //
+
+      public:
+        static size_t getTranscodedImageByteLength(transcoder_texture_format format,
+                                                   uint32_t width, uint32_t height)
+        {
+            uint32_t blockByteLength =
+                      basis_get_bytes_per_block_or_pixel(format);
+            if (basis_transcoder_format_is_uncompressed(format)) {
+                return width * height * blockByteLength;
+            } else if (format == transcoder_texture_format::cTFPVRTC1_4_RGB
+                       || format == transcoder_texture_format::cTFPVRTC1_4_RGBA) {
+                // For PVRTC1, Basis only writes (or requires)
+                // blockWidth * blockHeight * blockByteLength. But GL requires
+                // extra padding for very small textures:
+                // https://www.khronos.org/registry/OpenGL/extensions/IMG/IMG_texture_compression_pvrtc.txt
+                const uint32_t paddedWidth = (width + 3) & ~3;
+                const uint32_t paddedHeight = (height + 3) & ~3;
+                return (std::max(8U, paddedWidth)
+                        * std::max(8U, paddedHeight) * 4 + 7) / 8;
+            } else {
+                uint32_t blockWidth = getWidthInBlocks(width, basis_get_block_width(format));
+                uint32_t blockHeight = getHeightInBlocks(height, basis_get_block_height(format));
+                return blockWidth * blockHeight * blockByteLength;
+            }
+        }
+    };
+
+
+    class BasisLzEtc1sImageTranscoder : public basisu_etc1s_image_transcoder {
+      public:
+        BasisLzEtc1sImageTranscoder()
+                : basisu_etc1s_image_transcoder(buildSelectorCodebook()) { }
+
+        // Yes, code in the following functions handling data coming in from
+        // ArrayBuffers IS copying the data. Sigh! According to Alon Zakai:
+        //
+        //     "There isn't a way to let compiled code access a new ArrayBuffer.
+        //     The compiled code has hardcoded access to the wasm Memory it was
+        //     instantiated with - all the pointers it can understand are
+        //     indexes into that Memory. It can't refer to anything else,
+        //     I'm afraid."
+        //
+        //     "In the future using different address spaces or techniques with
+        //     reference types may open up some possibilities here."
+
+        bool decode_palettes(uint32_t num_endpoints, const val& jsEndpoints,
+                             uint32_t num_selectors, const val& jsSelectors)
+        {
+            std::vector<uint8_t> cEndpoints{}, cSelectors{};
+            val memory = val::module_property("HEAP8")["buffer"];
+            cEndpoints.resize(jsEndpoints["byteLength"].as<size_t>());
+            val endpointsView = jsEndpoints["constructor"].new_(memory,
+                                            reinterpret_cast<uintptr_t>(cEndpoints.data()),
+                                            jsEndpoints["length"].as<uint32_t>());
+            endpointsView.call<void>("set", jsEndpoints);
+
+            cSelectors.resize(jsSelectors["byteLength"].as<size_t>());
+            val selectorsView = jsSelectors["constructor"].new_(memory,
+                                            reinterpret_cast<uintptr_t>(cSelectors.data()),
+                                            jsSelectors["length"].as<uint32_t>());
+            selectorsView.call<void>("set", jsSelectors);
+
+            return basisu_etc1s_image_transcoder::decode_palettes(num_endpoints,
+                                                       cEndpoints.data(),
+                                                       cEndpoints.size(),
+                                                       num_selectors,
+                                                       cSelectors.data(),
+                                                       cSelectors.size());
+        }
+
+        bool decode_tables(const val& jsTableData)
+        {
+            std::vector<uint8_t> cTableData{};
+            val memory = val::module_property("HEAP8")["buffer"];
+
+            cTableData.resize(jsTableData["byteLength"].as<size_t>());
+            val TableDataView = jsTableData["constructor"].new_(memory,
+                                            reinterpret_cast<uintptr_t>(cTableData.data()),
+                                            jsTableData["length"].as<uint32_t>());
+            TableDataView.call<void>("set", jsTableData);
+
+            return basisu_etc1s_image_transcoder::decode_tables(
+                                                          cTableData.data(),
+                                                          cTableData.size());
+        }
+
+        // @~English
+        // @brief Transcode a single BasisLZ supercompressed ETC1S image.
+        //
+        // @param[in] targetFormat the format to which to transcode the image.
+        //                         This enum comes from Basis Universal.
+        // @param[in] jsInSlices   emscripten::val of a .subarray of the 
+        //                         ArrayBuffer holding the file data that
+        //                         points to the first slice for this image.
+        //                         An alpha slice, if it exists, always
+        //                         immediately follows the rgb slice.
+        // @param[in] imageDesc    reference to a struct basisu_image_desc
+        //                         giving information about the image.
+        // @param[in] decodeFlags
+        //                   an OR of basisu_decode_flags bits setting decode
+        //                   options. The only one of general interest is
+        //                   @c cDecodeFlagsTranscodeAlphaDataToOpaqueFormats.
+        //                   This can be used when @p targetFormat lacks an
+        //                   alpha component. When set the alpha slice is
+        //                   transcoded into the RGB components of the target.
+        //
+        // @return An emscripten::val with 1 entries, @c transcodedImage. If
+        //         the transcode failed, @c transcodedImage will be undefined.
+        //
+        emscripten::val transcode_image(
+                          transcoder_texture_format targetFormat,
+                          const val& jsInSlices,
+                          basisu_image_desc& imageDesc,
+                          uint32_t decodeFlags = 0,
+                          bool isVideo = false)
+        {
+            val memory = val::module_property("HEAP8")["buffer"];
+
+            // First of all copy in the deflated data.
+            std::vector <uint8_t> deflatedSlices;
+            uint32_t deflatedSlicesByteLength
+                                     = jsInSlices["byteLength"].as<uint32_t>();
+            deflatedSlices.resize(deflatedSlicesByteLength);
+            val memoryView = jsInSlices["constructor"].new_(memory,
+                             reinterpret_cast<uintptr_t>(deflatedSlices.data()),
+                             deflatedSlices.size());
+            memoryView.call<void>("set", jsInSlices);
+
+            size_t tiByteLength =
+            ImageTranscoderHelper::getTranscodedImageByteLength(targetFormat,
+                                                      imageDesc.m_orig_width,
+                                                      imageDesc.m_orig_height);
+            TranscodedImage* dst = new TranscodedImage(tiByteLength);
+
+            bool status = basisu_etc1s_image_transcoder::transcode_image(
+                                              targetFormat,
+                                              dst->data(),
+                                              dst->size(),
+                                              deflatedSlices.data(),
+                                              imageDesc,
+                                              decodeFlags,
+                                              isVideo);
+
+            val ret = val::object();
+            if (status) {
+                ret.set("transcodedImage", dst);
+            }
+            return std::move(ret);
+        }
+
+      protected:
+        static basist::etc1_global_selector_codebook* pGlobal_codebook;
+
+        static basist::etc1_global_selector_codebook*
+        buildSelectorCodebook()
+        {
+           if (!pGlobal_codebook) {
+                pGlobal_codebook = new basist::etc1_global_selector_codebook(
+                                                     g_global_selector_cb_size,
+                                                     g_global_selector_cb);
+            }
+            return pGlobal_codebook;
+        }
+    };
+
+    class UastcImageTranscoder : public basisu_uastc_image_transcoder {
+      public:
+        UastcImageTranscoder() : basisu_uastc_image_transcoder() { }
+
+        // @~English
+        // @brief Transcode a single UASTC encoded image.
+        //
+        // @param[in] targetFormat the format to which to transcode the image.
+        //                         This enum comes from Basis Universal.
+        // @param[in] jsInSlices   emscripten::val of a .subarray of the 
+        //                         ArrayBuffer holding the file data that
+        //                         points to the the image to transcode.
+        // @param[in] imageDesc    reference to a struct basisu_image_desc
+        //                         giving information about the image.
+        // @param[in] decodeFlags
+        //                   an OR of basisu_decode_flags bits setting decode
+        //                   options. The only one of general interest is
+        //                   @c cDecodeFlagsTranscodeAlphaDataToOpaqueFormats.
+        //                   This can be used when @p targetFormat lacks an
+        //                   alpha component. When set, the alpha components
+        //                   are decoded into the RGB components of the target.
+        //
+        // @return An emscripten::val with 1 entries, @c transcodedImage. If
+        //         the transcode failed, @c transcodedImage will be undefined.
+        //
+        emscripten::val transcode_image(
+                          transcoder_texture_format targetFormat,
+                          const val& jsInImage,
+                          basisu_image_desc& imageDesc,
+                          uint32_t decodeFlags = 0,
+                          bool hasAlpha = false,
+                          bool isVideo = false)
+        {
+            // Copy in the deflated image.
+            std::vector <uint8_t> deflatedImage;
+            size_t deflatedImageByteLength
+                                     = jsInImage["byteLength"].as<size_t>();
+            deflatedImage.resize(deflatedImageByteLength);
+            val memory = val::module_property("HEAP8")["buffer"];
+            val memoryView = jsInImage["constructor"].new_(memory,
+                              reinterpret_cast<uintptr_t>(deflatedImage.data()),
+                              deflatedImageByteLength);
+            memoryView.call<void>("set", jsInImage);
+
+            size_t tiByteLength =
+            ImageTranscoderHelper::getTranscodedImageByteLength(targetFormat,
+                                                      imageDesc.m_orig_width,
+                                                      imageDesc.m_orig_height);
+            TranscodedImage* dst = new TranscodedImage(tiByteLength);
+            bool status =
+                basisu_uastc_image_transcoder::transcode_image(
+                                              targetFormat,
+                                              dst->data(),
+                                              dst->size(),
+                                              deflatedImage.data(),
+                                              imageDesc,
+                                              decodeFlags,
+                                              hasAlpha,
+                                              isVideo);
+
+            val ret = val::object();
+            if (status) {
+                ret.set("transcodedImage", dst);
+            }
+            return std::move(ret);
+        }
+    };
+
+    basist::etc1_global_selector_codebook* BasisLzEtc1sImageTranscoder::pGlobal_codebook;
+}
+
+/** @page msc_basis_transcoder Basis Image Transcoder binding
+
+ ## WebIDL for the binding
+
+@code{.unparsed}
+void initTranscoders();
+
+bool isFormatSupported(TranscodeTarget targetFormat, TextureFormat texFormat);
+
+interface BasisTranscoderState {
+    void BasisTranscoderState();
+};
+
+interface TranscodedImage {
+    ArrayBufferView get_typed_memory_view();
+};
+
+interface TranscodeResult {
+    TranscodedImage transcodedImage;
+};
+
+interface BasisLzEtc1sImageTranscoder {
+    void BasisLzEtc1sImageTranscoder();
+    uint32_t getBytesPerBlock(TranscodeTarget format);
+    bool decode_palettes(uint32_t num_endpoints,
+                         const Uint8Array endpoints,
+                         uint32_t num_selectors,
+                         const Uint8Array selectors);
+    bool decode_tables(const Uint8Array tableData);
+    TranscodeResult transcode_image(
+                          TranscodeTarget targetFormat,
+                          const Uint8Array jsInSlices,
+                          ImageInfo imageInfo,
+                          uint32_t decodeFlags = 0,
+                          bool isVideo = false);
+};
+
+interface BasisUastcImageTranscoder {
+    void BasisUastcImageTranscoder();
+    uint32_t getBytesPerBlock(const TranscodeTarget format);
+    TranscodeResult transcode_image(
+                          TranscodeTarget targetFormat,
+                          const Uint8Array jsInImage,
+                          basisu_image_desc& imageDesc,
+                          uint32_t decodeFlags = 0,
+                          bool hasAlpha = false,
+                          bool isVideo = false);
+
+interface ImageInfo = {
+    ImageInfo(TextureFormat texFormat, uint32_t width, uint32_t height,
+              uint32_t level);
+    attribute uint32_t flags;
+    attribute long rgbByteOffset;
+    attribute long rgbByteLength;
+    attribute long alphaByteOffset;
+    attribute long alphaByteLength;
+    attribute uint32_t width;
+    attribute uint32_t height;
+    attribute uint32_t numBlocksX;
+    attribute uint32_t numBlocksY;
+    attribute uint32_t level;
+};
+
+// Some targets may not be available depending on options used when compiling
+// the web assembly.
+enum TranscodeTarget = {
+    "ETC1_RGB",
+    "BC1_RGB",
+    "BC4_R",
+    "BC5_RG",
+    "BC3_RGBA",
+    "PVRTC1_4_RGB",
+    "PVRTC1_4_RGBA",
+    "BC7_M6_RGB",
+    "BC7_M5_RGBA",
+    "ETC2_RGBA",
+    "ASTC_4x4_RGBA",
+    "RGBA32",
+    "RGB565",
+    "BGR565",
+    "RGBA4444",
+    "PVRTC2_4_RGB",
+    "PVRTC2_4_RGBA",
+    "EAC_R11",
+    "EAC_RG11"
+};
+
+enum TextureFormat = {
+    "ETC1S",
+    "UASTC4x4",
+};
+
+enum TranscodeFlagBits = 
+    "TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS",
+    "HIGH_QUALITY",
+};
+
+enum TranscodeFlagBits = {
+    "TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS",
+    "HIGH_QUALITY"
+};
+
+@endcode
+
+## How to use
+
+Put msc_basis_transcoder.js and msc_basis_transcoder.wasm in a
+directory on your server. Create a script tag with
+msc_basis_tranacoder.js as the @c src as shown below, changing
+the path as necessary for the relative locations of your .html
+file and the script source. msc_basis_transcoder.js will
+automatically load msc_basis_transcoder.wasm.
+
+### Create an instance of the MSC_TRANSCODER module
+
+For example, add this to the .html file to initialize the transcoder and
+make it available on the main window.
+@code{.unparsed}
+    &lt;script src="msc_transcoder_wrapper.js">&lt;/script>
+    &lt;script type="text/javascript">
+      MSC_TRANSCODER().then(module => {
+        window.MSC_TRANSCODER = module;
+        module.initTranscoders();
+        // Call a function to begin loading or transcoding..
+    &lt;/script>
+@endcode
+
+@e After the module is initialized, invoke code that will directly or indirectly cause
+a function with code like the following to be executed.
+
+## Somewhere in the loader/transcoder
+
+Assume a KTX file is fetched via an XMLHttpRequest which deposits the data into
+a Uint8Array, "buData"...
+
+@note The names of the data items used in the following code are those
+from the KTX2 specification but the actual data is not specific to that
+container format.
+
+@code{.unparsed}
+    const {
+        BasisLzEtc1sImageTranscoder,
+        BasisUastcImageTranscoder,
+        TranscodeTarget
+    } = MSC_TRANSCODER;
+
+    // Determine from the KTX2 header information in buData if
+    // the data format  is BasisU or Uastc.
+    // supercompressionScheme value == 1, it's TextureFormat.ETC1S.
+    // DFD colorModel == 166, it's TextureFormat.UASTC4x4.
+    const texFormat = ...
+
+    // Determine appropriate transcode format from available targets,
+    // info about the texture, e.g. texture.numComponents, and
+    // expected use. Use values from TranscodeTarget.
+    const targetFormat = ...
+    if ( !MSC_TRANSCODER.isFormatSupported(targetFormat, texFormat) {
+        throw new Error( ... );
+    }
+
+    if (TextureFormat.UASTC4x4) {
+        var result = transcodeUastc(targetFormat);
+    } else {
+        var result = transcodeEtc1s(targetFormat);
+    }
+    if ( result.transcodedImage === undefined ) {
+        throw new Error( 'Unable to transcode image.' );
+    }
+@endcode
+
+This is the function for transcoding etc1s.
+
+@code{.unparsed}
+transcodeEtc1s(targetFormat) {
+    // Locate the supercompression global data and compresssed
+    // mip level data within buData.
+
+    var bit = new BasisLzEtc1sImageTranscoder();
+
+    // Find the index of the starts of the endpoints, selectors and tables
+    // data within buData...
+    var endpointsStart = ...
+    var selectorsStart = ...
+    var tablesStart = ...
+    // The numbers of endpoints & selectors and their byteLengths are items
+    // within buData. They are in the header of a .ktx2 file's
+    // supercompressionGlobalData and in the header of a .basis file.
+
+    var endpoints = new Uint8Array(buData, endpointsStart,
+                                   endpointsByteLength);
+    var selectors = new Uint8Array(buData, selectorsStart,
+                                   selectorsByteLength);
+
+    bit.decodePalettes(numEndpoints, endpoints,
+                              numSelectors, selectors);
+
+    var tables = new UInt8Array(buData, tablesStart, tablesByteLength);
+    bit.decodeTables(tables);
+
+    // Determine if the file contains a video sequence...
+    var isVideo = ...
+
+    // Calculate the total number of images in the data
+    var numImages = ...
+
+    // Set up a subarray pointing at the deflated image descriptions
+    // in buData. This is for .ktx2 containers. The image descriptions
+    // are located in supercompressionGlobalData. .basis containers will
+    // require different code to locate the slice descriptions within
+    // the file.
+    var imageDescsStart = ...:
+    // An imageDesc has 5 uint32 values.
+    var imageDescs = new Uint32Data(buData, imageDescsStart,
+                                    numImages * 5 * 4);
+    var curImageIndex = 0;
+
+    // Pseudo code for processing the levels of a .ktx2 container...
+    foreach level {
+      var leveWidth = width of image at this level
+      var levelHeight = height of image at this level
+      imageInfo = new ImageInfo(TextureFormat::ETC1S, levelWidth, levelHeight,
+                                level);
+      foreach image in level {
+        // In KTX2 container locate the imageDesc for this image.
+        var imageDesc = imageDescs[curImageIndex++];
+        imageInfo.flags = imageDesc.imageFlags;
+        imageInfo.rgbByteOffset = 0;
+        imageInfo.rgbByteLength = imageDesc.rgbSliceByteLength;
+        imageInfo.alphaByteOffset = imageDesc.alphaSliceByteOffset > 0 ? imageDesc.rgbSliceByteLength : 0;
+        imageInfo.alphaByteLength = imageDesc.alphaSliceByteLength;
+        // Determine the location in the ArrayBuffer of the start
+        // of the deflated data for level.
+        var levelOffset = ...
+        // Make a .subarray of the rgb slice data.
+        var levelData = new Uint8Array(
+                     buData,
+                     levelOffset + imageDesc.rgbSliceByteOffset,
+                     imageDesc.rgbSliceByteLength + imageDesc.alphaByteLength
+                     );
+        var result = bit.transcodeImage(
+                                     targetFormat,
+                                     levelData,
+                                     imageInfo,
+                                     0,
+                                     isVideo);
+        if ( result.transcodedImage === undefined ) {
+            throw new Error( ... );
+        }
+        let imgData = transcodedImage.get_typed_memory_view();
+
+        // Upload data in imgData to WebGL...
+
+        // Do not call delete() until data has been uploaded
+        // or otherwise copied.
+        transcodedImage.delete();
+      }
+    }
+
+    // For .basis containers, it is necessary to locate the slice
+    // description(s) for the image and set the values in imageInfo
+    // from them. Use of the .basis-specific transcoder is recommended.
+    // The definition of the basis_slice_desc struct makes it difficult
+    // to create JS interface for it  with embind.
+@endcode
+
+This is the function for transcoding Uastc.
+
+@code{.unparsed}
+transcodeUastc(targetFormat) {
+    var uit = new UastcImageTranscoder();
+
+    // Determine if the data is supercompressed.
+    var zstd = (supercompressionScheme == 2);
+
+    // Determine if the data has alpha.
+    var hasAlpha = (Channel ID of sample[0] in DFD == 1);
+
+    var dctx;
+    if (zstd) {
+        // Initialize the zstd decoder. Zstd JS wrapper + wasm is
+        // a separate package.
+        dctx = ZSTD_createDCtx();
+    }
+
+    // Pseudo code for processing the levels of a .ktx2 container...
+    foreach level {
+      // Determine the location in the ArrayBuffer buData of the
+      // start of the deflated data for the level.
+      var levelData = ...
+      if (zstd) {
+          // Inflate the level data
+          levelData = ZSTD_decompressDCtx(dctx, levelData, ... );
+      }
+
+      var levelWidth = width of image at this level
+      var levelHeight = height of image at this level
+      var depth = depth of texture at this level
+      var levelImageCount = number of layers * number of faces * depth;
+      var imageOffsetInLevel = 0;
+
+      var imageInfo = new ImageInfo(TextureFormat::UASTC4x4,
+                                    levelWidth, levelHeight, level);
+      var levelImageByteLength = imageInfo.numBlocksX * imageInfo.numBlocksY * DFD bytesPlane0;
+
+      foreach image in level {
+        inImage = Uint8Array(levelData, imageOffsetInLevel, levelImageByteLength);
+        imageInfo.flags = 0;
+        imageInfo.rgbByteOffset = 0;
+        imageInfo.rgbByteLength = levelImageByteLength;
+        imageInfo.alphaByteOffset = 0;
+        imageInfo.alphaByteLength = 0;
+
+        const {transcodedImage} = uit.transcodeImage(
+                                                    targetFormat,
+                                                    inImage,
+                                                    imageInfo,
+                                                    0,
+                                                    hasAlpha,
+                                                    isVideo);
+       if ( result.transcodedImage === undefined ) {
+           throw new Error( ... );
+       }
+       let imgData = transcodedImage.get_typed_memory_view();
+
+       // Upload data in imgData to WebGL...
+
+       // Do not call delete() until data has been uploaded
+       // or otherwise copied.
+       transcodedImage.delete();
+
+       imageOffsetInLevel += levelImageByteLength;
+    }
+  }
+  // For .basis containers, as with ETC1S, it is necessary to locate
+  // the slice description for the image and set the values in imageInfo
+  // from it.
+}
+@endcode
+
+*/
+
+EMSCRIPTEN_BINDINGS(ktx_wrappers)
+{
+    enum_<transcoder_texture_format>("TranscodeTarget")
+        .value("ETC1_RGB", transcoder_texture_format::cTFETC1_RGB)
+        .value("BC1_RGB", transcoder_texture_format::cTFBC1_RGB)
+        .value("BC4_R", transcoder_texture_format::cTFBC4_R)
+        .value("BC5_RG", transcoder_texture_format::cTFBC5_RG)
+        .value("BC3_RGBA", transcoder_texture_format::cTFBC3_RGBA)
+        .value("PVRTC1_4_RGB", transcoder_texture_format::cTFPVRTC1_4_RGB)
+        .value("PVRTC1_4_RGBA", transcoder_texture_format::cTFPVRTC1_4_RGBA)
+        .value("BC7_M6_RGB", transcoder_texture_format::cTFBC7_M6_RGB)
+        .value("BC7_M5_RGBA", transcoder_texture_format::cTFBC7_M5_RGBA)
+        .value("ETC2_RGBA", transcoder_texture_format::cTFETC2_RGBA)
+        .value("ASTC_4x4_RGBA", transcoder_texture_format::cTFASTC_4x4_RGBA)
+        .value("RGBA32", transcoder_texture_format::cTFRGBA32)
+        .value("RGB565", transcoder_texture_format::cTFRGB565)
+        .value("BGR565", transcoder_texture_format::cTFBGR565)
+        .value("RGBA4444", transcoder_texture_format::cTFRGBA4444)
+        .value("PVRTC2_4_RGB", transcoder_texture_format::cTFPVRTC2_4_RGB)
+        .value("PVRTC2_4_RGBA", transcoder_texture_format::cTFPVRTC2_4_RGBA)
+        .value("EAC_R11", transcoder_texture_format::cTFETC2_EAC_R11)
+        .value("EAC_RG11", transcoder_texture_format::cTFETC2_EAC_RG11)
+    ;
+
+    enum_<basis_tex_format>("TextureFormat")
+        .value("ETC1S", basis_tex_format::cETC1S)
+        .value("UASTC4x4", basis_tex_format::cUASTC4x4)
+    ;
+
+    enum_<msc::TranscodeFlagBits>("TranscodeFlagBits")
+        .value("TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS",
+               msc::TranscodeAlphaDataToOpaqueFormats)
+        .value("HIGH_QUALITY", msc::HighQuality)
+    ;
+
+    function("initTranscoders", basisu_transcoder_init);
+    function("isFormatSupported", basis_is_format_supported);
+
+    class_<basisu_image_desc>("ImageInfo")
+        .constructor<basis_tex_format,uint32_t,uint32_t,uint32_t>()
+        .property("flags", &basisu_image_desc::m_flags)
+        .property("rgbByteOffset", &basisu_image_desc::m_rgb_byte_offset)
+        .property("rgbByteLength", &basisu_image_desc::m_rgb_byte_length)
+        .property("alphaByteOffset", &basisu_image_desc::m_alpha_byte_offset)
+        .property("alphaByteLength", &basisu_image_desc::m_alpha_byte_length)
+        .property("width", &basisu_image_desc::m_orig_width)
+        .property("height", &basisu_image_desc::m_orig_height)
+        .property("numBlocksX", &basisu_image_desc::m_num_blocks_x)
+        .property("numBlocksY", &basisu_image_desc::m_num_blocks_y)
+        .property("level", &basisu_image_desc::m_level)
+        ;
+
+    class_<msc::BasisLzEtc1sImageTranscoder>("BasisLzEtc1sImageTranscoder")
+        .constructor()
+        .class_function("getBytesPerBlock", basis_get_bytes_per_block_or_pixel)
+        .function("decodePalettes",
+                  &msc::BasisLzEtc1sImageTranscoder::decode_palettes)
+        .function("decodeTables",
+                  &msc::BasisLzEtc1sImageTranscoder::decode_tables)
+        .function("transcodeImage",
+                  &msc::BasisLzEtc1sImageTranscoder::transcode_image)
+        ;
+
+    class_<msc::UastcImageTranscoder>("UastcImageTranscoder")
+        .constructor()
+        .class_function("getBytesPerBlock", basis_get_bytes_per_block_or_pixel)
+        .function("transcodeImage",
+                  &msc::UastcImageTranscoder::transcode_image)
+        ;
+
+    class_<basisu_transcoder_state>("BasisTranscoderState")
+        .constructor()
+        ;
+
+    class_<msc::TranscodedImage>("TranscodedImage")
+        .function( "get_typed_memory_view",
+                  &msc::TranscodedImage::get_typed_memory_view )
+    ;
+
+}


### PR DESCRIPTION
* Makes transcode_image_level use these.
* Adds JS wrapper for these.
* Adds container independent lowlevel_*_transcode_slice methods with
  the old methods as inlines calling the new.
* Fixes clang 11 compile warnings.

libktx is using this code. `basisu` is also and I've used it to test all the transcode target formats for both etc1s and UASTC texture formats.

Note that this includes the recently merged PR fixing clang warnings in the transcoder. The way I fixed the comma operator warnings in non-transcoder code differs from the way they were fixed by that PR. I actually prefer the way the PR fixed them.

You might notice the parens removed from the IS_BIG_ENDIAN macros. These are to stop warnings about "this code will never be executed". 