### PR TITLE
Fix #44: document _ofs header fields

### DIFF
--- a/spec/basis_spec.txt
+++ b/spec/basis_spec.txt
@@ -105,11 +105,11 @@ struct basis_file_header
   uint32      m_userdata1;        // For client use
 
   uint16      m_total_endpoints;          // ETC1S: The number of endpoints in the endpoint codebook 
-  uint32      m_endpoint_cb_file_ofs;     // ETC1S: The compressed endpoint codebook's file offset relative to the header
+  uint32      m_endpoint_cb_file_ofs;     // ETC1S: The compressed endpoint codebook's file offset relative to the start of the file
   uint24      m_endpoint_cb_file_size;    // ETC1S: The compressed endpoint codebook's size in bytes
 
   uint16      m_total_selectors;          // ETC1S: The number of selectors in the selector codebook 
-  uint32      m_selector_cb_file_ofs;     // ETC1S: The compressed selector codebook's file offset relative to the header
+  uint32      m_selector_cb_file_ofs;     // ETC1S: The compressed selector codebook's file offset relative to the start of the file
   uint24      m_selector_cb_file_size;    // ETC1S: The compressed selector codebook's size in bytes
 
   uint32      m_tables_file_ofs;          // ETC1S: The file offset of the compressed Huffman codelength tables.
@@ -169,7 +169,7 @@ struct basis_slice_desc
 * m_orig_height: The original image height (may not be a multiple of 4 pixels)
 * m_num_blocks_x: The slice's block X dimensions. Each block is 4x4 pixels. The slice's pixel resolution may or may not be a power of 2.
 * m_num_blocks_y: The slice's block Y dimensions. 
-* m_file_ofs: Offset from the header to the start of the slice's data
+* m_file_ofs: Offset from the start of the file to the start of the slice's data
 * m_file_size: The size of the compressed slice data in bytes
 * m_slice_data_crc16: The CRC16 of the compressed slice data, for extra-paranoid use cases
 

--- a/transcoder/basisu_file_headers.h
+++ b/transcoder/basisu_file_headers.h
@@ -38,7 +38,7 @@ namespace basist
 		basisu::packed_uint<2> m_num_blocks_x;	// The slice's block X dimensions. Each block is 4x4 pixels. The slice's pixel resolution may or may not be a power of 2.
 		basisu::packed_uint<2> m_num_blocks_y;	// The slice's block Y dimensions. 
 
-		basisu::packed_uint<4> m_file_ofs;		// Offset from the header to the start of the slice's data
+		basisu::packed_uint<4> m_file_ofs;		// Offset from the start of the file to the start of the slice's data
 		basisu::packed_uint<4> m_file_size;		// The size of the compressed slice data in bytes
 
 		basisu::packed_uint<2> m_slice_data_crc16; // The CRC16 of the compressed slice data, for extra-paranoid use cases
@@ -107,11 +107,11 @@ namespace basist
 		basisu::packed_uint<4>      m_userdata1;		// For client use
 
 		basisu::packed_uint<2>      m_total_endpoints;			// The number of endpoints in the endpoint codebook 
-		basisu::packed_uint<4>      m_endpoint_cb_file_ofs;	// The compressed endpoint codebook's file offset relative to the header
+		basisu::packed_uint<4>      m_endpoint_cb_file_ofs;	// The compressed endpoint codebook's file offset relative to the start of the file
 		basisu::packed_uint<3>      m_endpoint_cb_file_size;	// The compressed endpoint codebook's size in bytes
 
 		basisu::packed_uint<2>      m_total_selectors;			// The number of selectors in the endpoint codebook 
-		basisu::packed_uint<4>      m_selector_cb_file_ofs;	// The compressed selectors codebook's file offset relative to the header
+		basisu::packed_uint<4>      m_selector_cb_file_ofs;	// The compressed selectors codebook's file offset relative to the start of the file
 		basisu::packed_uint<3>      m_selector_cb_file_size;	// The compressed selector codebook's size in bytes
 
 		basisu::packed_uint<4>      m_tables_file_ofs;			// The file offset of the compressed Huffman codelength tables, for decompressing slices


### PR DESCRIPTION
Image slices have m_file_ofs. It is not relative to the start of the header, it is relative to the
start of the file. Double-check basisu_basis_file.cpp:

`m_images_descs[i].m_file_ofs = (uint32_t)cur_slice_file_ofs;`

basis_file_header has m_endpoint_cb_file_ofs. It might be easier to read if the comment on it
just said "file offset," but to clear up any confusion if someone is re-reading the spec later
this commit leaves the "relative to the" language but clarifies it. Ditto for
m_selector_cb_file_ofs.