### PR TITLE
Fixed signed integer overflow

### DIFF
--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -3814,7 +3814,7 @@ namespace basist
 		assert(num_bits < 32);
 		assert(val < (1ULL << num_bits));
 
-		uint32_t mask = (1 << num_bits) - 1;
+		uint32_t mask = (1ULL << num_bits) - 1;
 
 		while (num_bits)
 		{


### PR DESCRIPTION
(1 << num_bits)  was converted to a signed integer that caused an overflow (as num_bits was usually set to 31). It worked fine since the value was later converted back to uint32_t but signed integer overflow is technically an undefined behavior and it was triggering errors in our automated tests.