### PR TITLE
Fixed alignment issue in unpack_uastc

### DIFF
--- a/transcoder/basisu_transcoder_uastc.h
+++ b/transcoder/basisu_transcoder_uastc.h
@@ -2,6 +2,15 @@
 #pragma once
 #include "basisu_transcoder_internal.h"
 
+#if defined(__GNUC__)
+	#define BASIS_ALIGNED(a) __attribute__ ((aligned (a)))
+#elif defined(_MSC_VER)
+	#define BASIS_ALIGNED(a) __declspec(align(a))
+#else
+	#warning "basist: struct alignment unsupported"
+	#define BASIS_ALIGNED(a)
+#endif
+
 namespace basist
 {
 	struct color_quad_u8
@@ -90,7 +99,7 @@ namespace basist
 		return k >> 8;
 	}
 
-	struct astc_block_desc
+	struct BASIS_ALIGNED(4) astc_block_desc
 	{
 		int m_weight_range;	// weight BISE range
 
@@ -199,7 +208,7 @@ namespace basist
 	int astc_compute_texel_partition(int seed, int x, int y, int z, int partitioncount, bool small_block);
 #endif
 		
-	struct uastc_block
+	struct BASIS_ALIGNED(4) uastc_block
 	{
 		union
 		{
@@ -212,7 +221,7 @@ namespace basist
 		};
 	};
 
-	struct unpacked_uastc_block
+	struct BASIS_ALIGNED(4) unpacked_uastc_block
 	{
 		astc_block_desc m_astc;
 


### PR DESCRIPTION
We had a user report a crash on an Amazon Fire device.
The callstack ended in `basist::unpack_uastc()` with a `SIGBUS` illegal alignment.

Since I don't have such a device myself, I tried aligning some of the relevant structs used in that function.
According to the user, it now works again.

I don't think this fix is very exhaustive (we only use UASTC), but it seems to work for us at least, so I wanted to highlight the issue for others.

(from our forum: https://forum.defold.com/t/blank-project-with-a-single-texture-crashes-on-amazon-fire-v1-2-180/67823)