### PR TITLE
Made it easier to use the library with external zstdlib implementations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ add_executable(basisu ${BASISU_SRC_LIST})
 
 if (ZSTD)
 	target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
+	target_include_directories(basisu PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/zstd)
 else()
 	target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
 endif()

--- a/encoder/basisu_comp.cpp
+++ b/encoder/basisu_comp.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #if BASISD_SUPPORT_KTX2_ZSTD
-#include "../zstd/zstd.h"
+#include <zstd.h>
 #endif
 
 // Set to 1 to disable the mipPadding alignment workaround (which only seems to be needed when no key-values are written at all)


### PR DESCRIPTION
Mostly for non CMake builds.

In our internal repository, we have our own version of zstdlib and introducing extra copy is both undesirable and potentially dangerous (due to ODR violations). This allows us to ignore the added zstd/ folder and use our own version of the library.