### PR TITLE
Fixed undefined behavior - signed integer overflow

### DIFF
--- a/encoder/basisu_enc.h
+++ b/encoder/basisu_enc.h
@@ -805,18 +805,18 @@ namespace basisu
 			int dg = e1.g - e2.g;
 			int db = e1.b - e2.b;
 
-			int delta_l = dr * 27 + dg * 92 + db * 9;
-			int delta_cr = dr * 128 - delta_l;
-			int delta_cb = db * 128 - delta_l;
+			uint32_t delta_l = dr * 27 + dg * 92 + db * 9;
+			uint32_t delta_cr = dr * 128 - delta_l;
+			uint32_t delta_cb = db * 128 - delta_l;
 
-			uint32_t id = ((uint32_t)(delta_l * delta_l) >> 7U) +
-				((((uint32_t)(delta_cr * delta_cr) >> 7U) * 26U) >> 7U) +
-				((((uint32_t)(delta_cb * delta_cb) >> 7U) * 3U) >> 7U);
+			uint32_t id = ((delta_l * delta_l) >> 7U) +
+				((((delta_cr * delta_cr) >> 7U) * 26U) >> 7U) +
+				((((delta_cb * delta_cb) >> 7U) * 3U) >> 7U);
 
 			if (alpha)
 			{
-				int da = (e1.a - e2.a) << 7;
-				id += ((uint32_t)(da * da) >> 7U);
+				uint32_t da = (e1.a - e2.a) << 7;
+				id += ((da * da) >> 7U);
 			}
 
 			return id;


### PR DESCRIPTION
Address sanitizer detected problem with signed integer overflow (e.g. delta_cr was -46843 and (-46843 * -46843) overflows).

Considering the results of these operations are always positive, it is safe to carry them out in uint32_t to begin with, e.g.:
  uint32_t a = -2;
  uint32_t b = a * a;
 |b| will still end up being 4 due to well-defined behavior of unsigned integer overflow. The result is going to be valid as long as (a * a) is representable by uint32_t and for all other values, the result will be in practice same as if it would be when uint32_t was replaced with int and result casted to uint32_t (i.e., the original implementation - with the caveat that the original implementation with the casting triggers the undefined behavior according to the C++ standard).