### PR TITLE
fix: Allow building SSE kernels regardless of SSE 4.2 being (in)active

### DIFF
--- a/encoder/basisu_kernels_sse.cpp
+++ b/encoder/basisu_kernels_sse.cpp
@@ -32,7 +32,7 @@
 			#error SSE4.1/SSE3/SSE4.2/SSSE3 cannot be enabled to use this file
 		#endif
 	#else
-		#if !__SSE4_1__ || !__SSE3__ || !__SSE4_2__ || !__SSSE3__
+		#if !__SSE4_1__ || !__SSE3__ || !__SSSE3__
 			#error Please check your compiler options
 		#endif
 	#endif

--- a/encoder/basisu_kernels_sse.cpp
+++ b/encoder/basisu_kernels_sse.cpp
@@ -32,7 +32,7 @@
 			#error SSE4.1/SSE3/SSE4.2/SSSE3 cannot be enabled to use this file
 		#endif
 	#else
-		#if !__SSE4_1__ || !__SSE3__ || __SSE4_2__ || !__SSSE3__
+		#if !__SSE4_1__ || !__SSE3__ || !__SSE4_2__ || !__SSSE3__
 			#error Please check your compiler options
 		#endif
 	#endif


### PR DESCRIPTION
I tried building KTX-Software for Android x86_64 and for some reason the Android NDK's compiler sets the define `__SSE4_2__` even though the SSE version is specified via `-msse4.1`:

```bash
$ /path/to/android-ndk-r21d/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=x86_64-none-linux-android24 -msse4.1 -dM -E - < /dev/null | egrep "SSE|AVX" | sort
#define __SSE__ 1
#define __SSE2__ 1
#define __SSE2_MATH__ 1
#define __SSE3__ 1
#define __SSE4_1__ 1
#define __SSE4_2__ 1
#define __SSE_MATH__ 1
#define __SSSE3__ 1
```
Removing paramter `--target=x86_64-none-linux-android24` would solve it, but this is added by the CMake Android toolchain and I'm afraid beyond my control.

This brings me to my question: Does this absolutely have to fail if `__SSE4_2__` is set? With the suggested change both basisu and KTX-Software build just fine, although I didn't run it yet.

Thanks for considering!

