### PR TITLE
fix the build on OpenBSD

### DIFF
--- a/encoder/basisu_enc.cpp
+++ b/encoder/basisu_enc.cpp
@@ -195,7 +195,7 @@ namespace basisu
 	{
 		QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(pTicks));
 	}
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__OpenBSD__)
 #include <sys/time.h>
 	inline void query_counter(timer_ticks* pTicks)
 	{


### PR DESCRIPTION
as per title, there isn't a `<sys/timex.h>` here.  (I suspect this is the case for other BSDs too, but can't check)

tested on OpenBSD-current with clang 11, but I used a similar patch to compile godot (which bundles basis_universal) for a while already.