### PR TITLE
Remove redundant definitions of min/max

### DIFF
--- a/encoder/basisu_resampler.cpp
+++ b/encoder/basisu_resampler.cpp
@@ -15,14 +15,6 @@
 #include "basisu_resampler.h"
 #include "basisu_resampler_filters.h"
 
-#ifndef max
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#endif
-
-#ifndef min
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-
 #define RESAMPLER_DEBUG 0
 
 namespace basisu


### PR DESCRIPTION
These aren't used and they conflict with other sources in single-source
build.