### PR TITLE
Disallow all-zero-length Huffman tables

### DIFF
--- a/transcoder/basisu_transcoder_internal.h
+++ b/transcoder/basisu_transcoder_internal.h
@@ -160,7 +160,7 @@ namespace basist
 				next_code[i + 1] = (total = ((total + syms_using_codesize[i]) << 1));
 			}
 
-			if (((1U << basisu::cHuffmanMaxSupportedInternalCodeSize) != total) && (used_syms > 1U))
+			if (((1U << basisu::cHuffmanMaxSupportedInternalCodeSize) != total) && (used_syms != 1U))
 				return false;
 
 			for (int tree_next = -1, sym_index = 0; sym_index < (int)total_syms; ++sym_index)


### PR DESCRIPTION
`huffman_decoding_table::init` allowed code lengths like `[0, 0]`, which should be invalid. Alternatively, if such inputs are valid this should be documented.