### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/encoder/basisu_enc.cpp
+++ b/encoder/basisu_enc.cpp
@@ -195,7 +195,7 @@ namespace basisu
 	{
 		QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(pTicks));
 	}
-#elif defined(__APPLE__) || defined(__OpenBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/time.h>
 	inline void query_counter(timer_ticks* pTicks)
 	{


### PR DESCRIPTION
Follow-up to https://github.com/BinomialLLC/basis_universal/pull/234. Downstream issues/PRs: https://github.com/godotengine/godot/pull/55139, https://github.com/godotengine/godot/issues/55138

Linux's `<sys/timex.h>` header was used instead of FreeBSD's <sys/time.h> due to missing preprocessor comparison.