### PR TITLE
Adds CLI options for finer control of input resampling

### DIFF
--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -127,8 +127,12 @@ static void print_usage()
 		" -disable_hierarchical_endpoint_codebooks: Disable hierarchical endpoint codebook usage, slower but higher quality on some compression levels\n"
 		" -compare_ssim: Compute and display SSIM of image comparison (slow)\n"
 		" -bench: UASTC benchmark mode, for development only\n"
-		" -resample X Y: Resample all input textures to XxY pixels using a box filter\n"
-		" -resample_factor X: Resample all input textures by scale factor X using a box filter\n"
+		" -resample X Y: Resample all input images to XxY pixels\n"
+		" -resample_factor X: Resample all input images by scale factor X\n"
+		" -resample_filter X: Set resample filter kernel, default is box, filters: box, tent, bell, blackman, catmullrom, mitchell, etc.\n"
+		" -resample_filter_scale X: Set resample filter kernel's scale, lower=sharper, higher=more blurry, default is 1.0\n"
+		" -resample_ifgt: Only resample if the image is larger than width or height provided with -resample\n"
+		" -resample_aspect: Keep aspect ratio of image while resampling. \"fit\" the image inside the -resample rectangle\n"
 		" -no_sse: Forbid all SSE instruction set usage\n"
 		" -validate_etc1s: Validate internal ETC1S compressor's data structures during compression (slower, intended for development).\n"
 		"\n"
@@ -405,6 +409,27 @@ public:
 				REMAINING_ARGS_CHECK(1);
 				m_comp_params.m_resample_factor = (float)atof(arg_v[arg_index + 1]);
 				arg_count++;
+			}
+			else if (strcasecmp(pArg, "-resample_filter") == 0)
+			{
+				REMAINING_ARGS_CHECK(1);
+				m_comp_params.m_resample_filter = arg_v[arg_index + 1];
+				// TODO: Check filter
+				arg_count++;
+			}
+			else if (strcasecmp(pArg, "-resample_filter_scale") == 0)
+			{
+				REMAINING_ARGS_CHECK(1);
+				m_comp_params.m_resample_filter_scale = (float)atof(arg_v[arg_index + 1]);
+				arg_count++;
+			}
+			else if (strcasecmp(pArg, "-resample_ifgt") == 0)
+			{
+				m_comp_params.m_resample_ifgt = true;
+			}
+			else if (strcasecmp(pArg, "-resample_aspect") == 0)
+			{
+				m_comp_params.m_resample_aspect = true;
 			}
 			else if (strcasecmp(pArg, "-uastc_rdo_l") == 0)
 			{

--- a/encoder/basisu_comp.cpp
+++ b/encoder/basisu_comp.cpp
@@ -551,12 +551,32 @@ namespace basisu
 				int new_width = basisu::minimum<int>(m_params.m_resample_width, BASISU_MAX_SUPPORTED_TEXTURE_DIMENSION);
 				int new_height = basisu::minimum<int>(m_params.m_resample_height, BASISU_MAX_SUPPORTED_TEXTURE_DIMENSION);
 
-				debug_printf("Resampling to %ix%i\n", new_width, new_height);
+				int src_width = (int)file_image.get_width();
+				int src_height = (int)file_image.get_height();
 
-				// TODO: A box filter - kaiser looks too sharp on video. Let the caller control this.
-				image temp_img(new_width, new_height);
-				image_resample(file_image, temp_img, m_params.m_perceptual, "box"); // "kaiser");
-				temp_img.swap(file_image);
+				if (!m_params.m_resample_ifgt || new_width < src_width || new_height < src_height)
+				{
+					if (m_params.m_resample_aspect)
+					{
+						if (src_width > src_height)
+						{
+							new_height = (int)roundf((float)new_width * (float)src_height / (float)src_width);
+						}
+						else
+						{
+							new_width = (int)roundf((float)new_height * (float)src_width / (float)src_height);
+						}
+					}
+					debug_printf("\n\nResampling %ix%i -> %ix%i\n\n", src_width, src_height, new_width, new_height);
+
+					image temp_img(new_width, new_height);
+					image_resample(file_image, temp_img, m_params.m_perceptual, m_params.m_resample_filter.c_str(), m_params.m_resample_filter_scale);
+					temp_img.swap(file_image);
+				}
+				else
+				{
+					debug_printf("Resampling skipped since source is <= %ix%i\n", (int)m_params.m_resample_width, (int)m_params.m_resample_height);
+				}
 			}
 			else if (m_params.m_resample_factor > 0.0f)
 			{
@@ -567,7 +587,7 @@ namespace basisu
 
 				// TODO: A box filter - kaiser looks too sharp on video. Let the caller control this.
 				image temp_img(new_width, new_height);
-				image_resample(file_image, temp_img, m_params.m_perceptual, "box"); // "kaiser");
+				image_resample(file_image, temp_img, m_params.m_perceptual, m_params.m_resample_filter.c_str(), m_params.m_resample_filter_scale);
 				temp_img.swap(file_image);
 			}
 

--- a/encoder/basisu_comp.cpp
+++ b/encoder/basisu_comp.cpp
@@ -567,7 +567,7 @@ namespace basisu
 							new_width = (int)roundf((float)new_height * (float)src_width / (float)src_height);
 						}
 					}
-					debug_printf("\n\nResampling %ix%i -> %ix%i\n\n", src_width, src_height, new_width, new_height);
+					debug_printf("Resampling %ix%i -> %ix%i\n", src_width, src_height, new_width, new_height);
 
 					image temp_img(new_width, new_height);
 					image_resample(file_image, temp_img, m_params.m_perceptual, m_params.m_resample_filter.c_str(), m_params.m_resample_filter_scale);

--- a/encoder/basisu_comp.cpp
+++ b/encoder/basisu_comp.cpp
@@ -585,7 +585,6 @@ namespace basisu
 
 				debug_printf("Resampling to %ix%i\n", new_width, new_height);
 
-				// TODO: A box filter - kaiser looks too sharp on video. Let the caller control this.
 				image temp_img(new_width, new_height);
 				image_resample(file_image, temp_img, m_params.m_perceptual, m_params.m_resample_filter.c_str(), m_params.m_resample_filter_scale);
 				temp_img.swap(file_image);

--- a/encoder/basisu_comp.h
+++ b/encoder/basisu_comp.h
@@ -225,6 +225,8 @@ namespace basisu
 			m_resample_width(0, 1, 16384),
 			m_resample_height(0, 1, 16384),
 			m_resample_factor(0.0f, .00125f, 100.0f),
+			m_resample_filter("box"),
+			m_resample_filter_scale(1.0f, .000125f, 4.0f),
 			m_ktx2_uastc_supercompression(basist::KTX2_SS_NONE),
 			m_ktx2_zstd_supercompression_level(6, INT_MIN, INT_MAX),
 			m_pJob_pool(nullptr)
@@ -310,6 +312,10 @@ namespace basisu
 			m_resample_width.clear();
 			m_resample_height.clear();
 			m_resample_factor.clear();
+			m_resample_filter = "box";
+			m_resample_filter_scale = 1.0f;
+			m_resample_ifgt.clear();
+			m_resample_aspect.clear();
 
 			m_pGlobal_codebooks = nullptr;
 
@@ -444,6 +450,10 @@ namespace basisu
 		param<int> m_resample_width;
 		param<int> m_resample_height;
 		param<float> m_resample_factor;
+		std::string m_resample_filter;
+		param<float> m_resample_filter_scale;
+		bool_param<false> m_resample_ifgt;
+		bool_param<false> m_resample_aspect;
 		const basist::basisu_lowlevel_etc1s_transcoder *m_pGlobal_codebooks;
 
 		// KTX2 specific parameters.


### PR DESCRIPTION
First off, thank you for this lovely software!

This patch adds four command-line options to the encoder tool for increased control of input preprocessing resampling:
- `-resample_filter X` Set resample filter kernel, default is box, filters: box, tent, bell, blackman, catmullrom, mitchell, etc.
- `-resample_filter_scale X` Set resample filter kernel's scale, lower=sharper, higher=more blurry, default is 1.0
- `-resample_ifgt` Only resample if the image is larger than width or height provided with -resample
- `-resample_aspect` Keep aspect ratio of image while resampling. "fit" the image inside the -resample rectangle

I've tried my best to match the style of the existing code and have of course tested all this with a bunch of different inputs.

## Examples

Resample inputs using lanczos3 filter with a 0.8 scale factor:
```
basisu -resample 512 512 -resample_filter lanczos3 -resample_filter_scale 0.8 a.png
```

Resample inputs to fit within 512x512, maintaining their aspect ratio:
```
basisu -resample 512 512 -resample_aspect a.png
```

Resample inputs only if the width is larger than 1024 or if the height is larger than 512:
```
basisu -resample 1024 512 -resample_ifgt a.png
```
