### PR TITLE
Minor: invalid char triggers Unicode error

### DIFF
--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -16990,7 +16990,7 @@ namespace basist
 		{
 			m_format = basist::basis_tex_format::cETC1S;
 			
-			// 3.10.2: "Whether the image has 1 or 2 slices can be determined from the DFD’s sample count."
+			// 3.10.2: "Whether the image has 1 or 2 slices can be determined from the DFD's sample count."
 			// If m_has_alpha is true it may be 2-channel RRRG or 4-channel RGBA, but we let the caller deal with that.
 			m_has_alpha = (m_header.m_dfd_byte_length == 60);
 			


### PR DESCRIPTION
This is a one character change but it was triggering issues when parsing the code as UTF-8.

![apostrophe](https://user-images.githubusercontent.com/8437014/150161480-9ef06c57-cdd2-4d5a-b49c-cd3990ed0ba7.png)

Which triggers this when pre-processing the source with Python's parser:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x92 in position 5297: invalid start byte
```
A regular text editor ignores it.