### PR TITLE
Add `-format_only` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To use the command line tool to unpack a .basis or .KTX2 file to multiple .png/.
 
 `basisu x.basis`
 
-Use the `-no_ktx` and `-etc1_only` options to unpack to less files. `-info` and `-validate` will just display file information and not output any files. The output .KTX1 files are currently in the KTX1 file format, not KTX2.
+Use the `-no_ktx`/`-ktx_only` and `-etc1_only`/`-format_only` options to unpack to less files. `-info` and `-validate` will just display file information and not output any files. The output .KTX1 files are currently in the KTX1 file format, not KTX2.
 
 The mipmapped or cubemap .KTX files will be in a wide variety of compressed GPU texture formats (PVRTC1 4bpp, ETC1-2, BC1-5, BC7, etc.), and to my knowledge there is no single .KTX viewer tool that correctly and reliably supports every GPU texture format that we support. BC1-5 and BC7 files are viewable using AMD's Compressonator, ETC1/2 using Mali's Texture Compression Tool, and PVRTC1 using Imagination Tech's PVRTexTool. Links:
 
@@ -313,4 +313,3 @@ licensing to ensure the entire repository has explicit licensing information.
 To ensure continued REUSE compliance, run `reuse lint` at the root of
 a clean, checked-out repository periodically, or run it during CI tests
 before any build artifacts have been created.
-

--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -136,6 +136,7 @@ static void print_usage()
 		" -no_ktx: Disable KTX writing when unpacking (faster, less output files)\n"
 		" -ktx_only: Only write KTX files when unpacking (faster, less output files)\n"
 		" -write_out: Write 3dfx OUT files when unpacking FXT1 textures\n"
+		" -format_only: Only unpack the specified format, by its numeric code.\n"
 		" -etc1_only: Only unpack to ETC1, skipping the other texture formats during -unpack\n"
 		" -disable_hierarchical_endpoint_codebooks: Disable hierarchical endpoint codebook usage, slower but higher quality on some compression levels\n"
 		" -compare_ssim: Compute and display SSIM of image comparison (slow)\n"
@@ -286,6 +287,7 @@ public:
 		m_no_ktx(false),
 		m_ktx_only(false),
 		m_write_out(false),
+		m_format_only(-1),
 		m_etc1_only(false),
 		m_fuzz_testing(false),
 		m_compare_ssim(false),
@@ -613,8 +615,17 @@ public:
 				m_ktx_only = true;
 			else if (strcasecmp(pArg, "-write_out") == 0)
 				m_write_out = true;
+			else if (strcasecmp(pArg, "-format_only") == 0)
+			{
+				REMAINING_ARGS_CHECK(1);
+				m_format_only = atoi(arg_v[arg_index + 1]);
+				arg_count++;
+			}
 			else if (strcasecmp(pArg, "-etc1_only") == 0)
+			{
 				m_etc1_only = true;
+				m_format_only = (int)basist::transcoder_texture_format::cTFETC1_RGB;
+			}
 			else if (strcasecmp(pArg, "-disable_hierarchical_endpoint_codebooks") == 0)
 				m_comp_params.m_disable_hierarchical_endpoint_codebooks = true;
 			else if (strcasecmp(pArg, "-opencl") == 0)
@@ -822,6 +833,8 @@ public:
 
 	std::string m_output_filename;
 	std::string m_output_path;
+
+	int m_format_only;
 
 	std::string m_multifile_printf;
 	uint32_t m_multifile_first;
@@ -1487,9 +1500,9 @@ static bool unpack_and_validate_ktx2_file(
 	int first_format = 0;
 	int last_format = (int)basist::transcoder_texture_format::cTFTotalTextureFormats;
 
-	if (opts.m_etc1_only)
+	if (opts.m_format_only > -1)
 	{
-		first_format = (int)basist::transcoder_texture_format::cTFETC1_RGB;
+		first_format = opts.m_format_only;
 		last_format = first_format + 1;
 	}
 
@@ -1894,9 +1907,9 @@ static bool unpack_and_validate_basis_file(
 	int first_format = 0;
 	int last_format = (int)basist::transcoder_texture_format::cTFTotalTextureFormats;
 
-	if (opts.m_etc1_only)
+	if (opts.m_format_only > -1)
 	{
-		first_format = (int)basist::transcoder_texture_format::cTFETC1_RGB;
+		first_format = opts.m_format_only;
 		last_format = first_format + 1;
 	}
 


### PR DESCRIPTION
A more flexible variant of `-etc1_only`.

Works well with `-ktx_only` to produce a specific output.

Fixes the remaining part of #227 