### PR TITLE
Ensure interval_timer is initialized from main thread

### DIFF
--- a/encoder/basisu_enc.cpp
+++ b/encoder/basisu_enc.cpp
@@ -187,6 +187,8 @@ namespace basisu
 			opencl_init(opencl_force_serialization);
 		}
 
+		interval_timer::init(); // make sure interval_timer globals are initialized from main thread to avoid TSAN reports
+
 		g_library_initialized = true;
 	}
 


### PR DESCRIPTION
This avoids the race condition in interval_timer::init which triggers
thread sanitizer errors.

Fixes #317.