### PR TITLE
Disable dynamic execution in WASM build to allow removal of unsafe-eval

### DIFF
--- a/webgl/transcoder/CMakeLists.txt
+++ b/webgl/transcoder/CMakeLists.txt
@@ -48,5 +48,5 @@ if (EMSCRIPTEN)
   set_target_properties(basis_transcoder.js PROPERTIES
       OUTPUT_NAME "basis_transcoder"
       SUFFIX ".js"
-      LINK_FLAGS "--bind -s ALLOW_MEMORY_GROWTH=1 -O3 -s ASSERTIONS=0 -s MALLOC=emmalloc -s MODULARIZE=1 -s EXPORT_NAME=BASIS ")
+      LINK_FLAGS "--bind -s ALLOW_MEMORY_GROWTH=1 -O3 -s ASSERTIONS=0 -s MALLOC=emmalloc -s MODULARIZE=1 -s EXPORT_NAME=BASIS -s NO_DYNAMIC_EXECUTION=1")
 endif()


### PR DESCRIPTION
The current WASM build generates a loader that uses `new Function()`, which performs a Javascript `eval`. This is problematic if you want to use a CSP on your site that does not allow `unsafe-eval` - in other words, if you want to use the transcoder, you're forced to enable `eval` on your site.

The `NO_DYNAMIC_EXECUTION` flag can be used to disable the dynamic execution facilities of the module, which avoids the use of eval but drops support for a few emscripten functions (https://github.com/emscripten-core/emscripten/blob/main/src/settings.js#L1256) which seem unneeded for Basis's use cases. (I may be wrong about this, so hope the PR reviewer can confirm.)

This PR enables this option which re-enables site admins to disable `eval` on sites which use the basis transcoder.

Thanks for considering the PR!