### PR TITLE
Allow defining BASISU_HAVE_STD_TRIVIALLY_COPYABLE

### DIFF
--- a/transcoder/basisu_containers.h
+++ b/transcoder/basisu_containers.h
@@ -188,7 +188,7 @@ namespace basisu
 
 #define BASISU_IS_SCALAR_TYPE(T) (scalar_type<T>::cFlag)
 
-#if defined(__GNUC__) && __GNUC__<5
+#if !defined(BASISU_HAVE_STD_TRIVIALLY_COPYABLE) && defined(__GNUC__) && __GNUC__<5
    #define BASISU_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
 #else
    #define BASISU_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value


### PR DESCRIPTION
To force `std::is_trivially_copyable`.

Allows the library consumer to resolve issues with some build environments (for example, Clang-based build environments) that may actually provide `std::is_trivially_copyable` but may also define `__GNUC__` (< 5).

The latest versions of Clang (Clang 15+) may trigger a warning / error without this, as they have deprecated `__has_trivial_copy` and will throw `-Wdeprecated-builtins` @richgel999

Example:

```
Error: .../transcoder/basisu_containers.h:745:19: error: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Werror,-Wdeprecated-builtins]
            if ((!BASISU_IS_BITWISE_COPYABLE(T)) || (BASISU_HAS_DESTRUCTOR(T)))
                  ^
.../transcoder/basisu_containers.h:198:88: note: expanded from macro 'BASISU_IS_BITWISE_COPYABLE'
#define BASISU_IS_BITWISE_COPYABLE(T) (BASISU_IS_SCALAR_TYPE(T) || BASISU_IS_POD(T) || BASISU_IS_TRIVIALLY_COPYABLE(T) || (bitwise_copyable<T>::cFlag))
                                                                                       ^
.../transcoder/basisu_containers.h:192:46: note: expanded from macro 'BASISU_IS_TRIVIALLY_COPYABLE'
   #define BASISU_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
```