### PR TITLE
Trying to fix up the cmake script to be more consumable by downstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,20 @@ cmake_minimum_required(VERSION 3.0)
 option(STATIC "static linking" FALSE)
 option(SAN "sanitize" FALSE)
 
+# Ensures that shared libraries will export import libraries
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 # For MSVC builds default to SSE enabled, and determine if it's a 64-bit (-A x64) vs. 32-bit (-A Win32) build.
 if (MSVC)
-	option(SSE "SSE 4.1 support" TRUE)
-	if ( CMAKE_GENERATOR_PLATFORM STREQUAL Win32 )	
-		set(BUILD_X64 0)
-	else()
-		set(BUILD_X64 1)
-	endif()
+  option(SSE "SSE 4.1 support" TRUE)
+  if ( CMAKE_GENERATOR_PLATFORM STREQUAL Win32 )	
+    set(BUILD_X64 0)
+  else()
+    set(BUILD_X64 1)
+  endif()
 else()
-	option(SSE "SSE 4.1 support" FALSE)
-	option(BUILD_X64 "build 64-bit" TRUE)
+  option(SSE "SSE 4.1 support" FALSE)
+  option(BUILD_X64 "build 64-bit" TRUE)
 endif()
 
 option(ZSTD "ZSTD support for KTX2 transcoding/encoding" TRUE)
@@ -28,12 +31,12 @@ message("Initial OPENCL=${OPENCL}")
 message("Initial SAN=${SAN}")
 
 if (NOT MSVC)
-	# With MSVC builds we use the Khronos lib/include files in the project's "OpenCL" directory, to completely avoid requiring fiddly to install vendor SDK's.
-	# Otherwise we use the system's (if any).
-	find_package( OpenCL )
-	message(STATUS "OpenCL found: ${OPENCL_FOUND}")
-	message(STATUS "OpenCL includes: ${OpenCL_INCLUDE_DIRS}")
-	message(STATUS "OpenCL libraries: ${OpenCL_LIBRARIES}")
+  # With MSVC builds we use the Khronos lib/include files in the project's "OpenCL" directory, to completely avoid requiring fiddly to install vendor SDK's.
+  # Otherwise we use the system's (if any).
+  find_package( OpenCL )
+  message(STATUS "OpenCL found: ${OPENCL_FOUND}")
+  message(STATUS "OpenCL includes: ${OpenCL_INCLUDE_DIRS}")
+  message(STATUS "OpenCL libraries: ${OpenCL_LIBRARIES}")
 endif()
 
 if( NOT CMAKE_BUILD_TYPE )
@@ -43,21 +46,21 @@ endif()
 message( ${PROJECT_NAME} " build type: " ${CMAKE_BUILD_TYPE} )
 
 if (BUILD_X64)
-	message("Building 64-bit")
+  message("Building 64-bit")
 else()
-	message("Building 32-bit")
+  message("Building 32-bit")
 endif()
 
 if (SSE)
-	message("SSE enabled")
+  message("SSE enabled")
 else()
-	message("SSE disabled")
+  message("SSE disabled")
 endif()
 
 if (ZSTD)
-	message("Zstandard enabled")
+  message("Zstandard enabled")
 else()
-	message("Zstandard disabled")
+  message("Zstandard disabled")
 endif()
 
 if (NOT MSVC)
@@ -76,34 +79,34 @@ if (NOT MSVC)
    set(GCC_COMPILE_FLAGS "-fvisibility=hidden -fPIC -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wno-unused-local-typedefs -Wno-unused-value -Wno-unused-parameter -Wno-unused-variable")
 
    if (NOT BUILD_X64)
-	  set(GCC_COMPILE_FLAGS "${GCC_COMPILE_FLAGS} -m32")
+    set(GCC_COMPILE_FLAGS "${GCC_COMPILE_FLAGS} -m32")
    endif()
 
    if (EMSCRIPTEN)
-	  set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -s ALLOW_MEMORY_GROWTH=1 -DBASISU_SUPPORT_SSE=0")
-	  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -s ALLOW_MEMORY_GROWTH=1 -DBASISU_SUPPORT_SSE=0")
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -s ALLOW_MEMORY_GROWTH=1 -DBASISU_SUPPORT_SSE=0")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -s ALLOW_MEMORY_GROWTH=1 -DBASISU_SUPPORT_SSE=0")
 
-	  set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS}")
    elseif (STATIC)
       if (SSE)
-		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=1 -msse4.1")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=1 -msse4.1")
-	  else()
-	  	set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=0")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=0")
-	  endif()
-	  
-	  set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS} -static-libgcc -static-libstdc++ -static")
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=1 -msse4.1")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=1 -msse4.1")
+    else()
+      set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=0")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=0")
+    endif()
+    
+    set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS} -static-libgcc -static-libstdc++ -static")
    else()
-   	  if (SSE)
-		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=1 -msse4.1")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=1 -msse4.1")
-	  else()
-	  	set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=0")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=0")
-	  endif()
-	  
-	  set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS} -Wl,-rpath .")
+       if (SSE)
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=1 -msse4.1")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=1 -msse4.1")
+    else()
+      set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=0")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=0")
+    endif()
+    
+    set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS} -Wl,-rpath .")
    endif()
 
    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${GCC_COMPILE_FLAGS}")
@@ -114,39 +117,50 @@ if (NOT MSVC)
    set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} ${GCC_COMPILE_FLAGS}")
    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${GCC_COMPILE_FLAGS} -D_DEBUG")
 else()
-	if (SSE)
-		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=1")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=1")
-	else()
-		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=0")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=0")
-	endif()
+  if (SSE)
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=1")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=1")
+  else()
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=0")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=0")
+  endif()
 endif()
 
-set(BASISU_SRC_LIST ${COMMON_SRC_LIST} 
-	basisu_tool.cpp
-	encoder/basisu_backend.cpp
-	encoder/basisu_basis_file.cpp
-	encoder/basisu_comp.cpp
-	encoder/basisu_enc.cpp
-	encoder/basisu_etc.cpp
-	encoder/basisu_frontend.cpp
-	encoder/basisu_gpu_texture.cpp
-	encoder/basisu_pvrtc1_4.cpp
-	encoder/basisu_resampler.cpp
-	encoder/basisu_resample_filters.cpp
-	encoder/basisu_ssim.cpp
-	encoder/basisu_uastc_enc.cpp
-	encoder/basisu_bc7enc.cpp
-	encoder/jpgd.cpp
-	encoder/basisu_kernels_sse.cpp
-	encoder/basisu_opencl.cpp
-	encoder/pvpngreader.cpp
-	transcoder/basisu_transcoder.cpp
-	)
+set(BASISU_TRANS_SRC_LIST
+  transcoder/basisu_transcoder.cpp
+)
+
+set(BASISU_ENC_SRC_LIST
+  encoder/basisu_backend.cpp
+  encoder/basisu_basis_file.cpp
+  encoder/basisu_comp.cpp
+  encoder/basisu_enc.cpp
+  encoder/basisu_etc.cpp
+  encoder/basisu_frontend.cpp
+  encoder/basisu_gpu_texture.cpp
+  encoder/basisu_pvrtc1_4.cpp
+  encoder/basisu_resampler.cpp
+  encoder/basisu_resample_filters.cpp
+  encoder/basisu_ssim.cpp
+  encoder/basisu_uastc_enc.cpp
+  encoder/basisu_bc7enc.cpp
+  encoder/jpgd.cpp
+  encoder/basisu_kernels_sse.cpp
+  encoder/basisu_opencl.cpp
+  encoder/pvpngreader.cpp
+  ${BASISU_TRANS_SRC_LIST}
+)
+
+set(BASISU_SRC_LIST
+  basisu_tool.cpp
+  encoder/basisu_enc.cpp
+  ${BASISU_TRANS_SRC_LIST}
+)
 
 if (ZSTD)
-	set(BASISU_SRC_LIST ${BASISU_SRC_LIST} zstd/zstd.c)
+  set(BASISU_SRC_LIST ${BASISU_SRC_LIST} zstd/zstd.c)
+  set(BASISU_ENC_SRC_LIST ${BASISU_ENC_SRC_LIST} zstd/zstd.c)
+  set(BASISU_TRANS_SRC_LIST ${BASISU_TRANS_SRC_LIST} zstd/zstd.c)
 endif()
 
 if (APPLE)
@@ -157,55 +171,106 @@ endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${BIN_DIRECTORY})
 
+add_library(basisu_transcoder ${BASISU_TRANS_SRC_LIST})
+add_library(basisu_encoder ${BASISU_ENC_SRC_LIST})
 add_executable(basisu ${BASISU_SRC_LIST})
 
+target_include_directories(basisu_encoder PUBLIC 
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/encoder>
+  $<INSTALL_INTERFACE:encoder/>)
+target_include_directories(basisu_transcoder PUBLIC 
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/transcoder>
+  $<INSTALL_INTERFACE:transcoder/>)
+
+target_link_libraries(basisu PRIVATE basisu_encoder basisu_transcoder)
+
 if (ZSTD)
-	target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
+  target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
+  target_compile_definitions(basisu_encoder PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
+  target_compile_definitions(basisu_transcoder PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
 else()
-	target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
+  target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
+  target_compile_definitions(basisu_encoder PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
+  target_compile_definitions(basisu_transcoder PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
 endif()
 
 if (NOT MSVC)
-	# For Non-Windows builds, let cmake try and find the system OpenCL headers/libs for us.
-	if (OPENCL_FOUND)
-		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_OPENCL=1")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_OPENCL=1")	
-		
-		target_include_directories( basisu PRIVATE ${OpenCL_INCLUDE_DIRS} )
-		set(BASISU_EXTRA_LIBS ${OpenCL_LIBRARIES})
-	endif()
+  # For Non-Windows builds, let cmake try and find the system OpenCL headers/libs for us.
+  if (OPENCL_FOUND)
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_OPENCL=1")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_OPENCL=1")	
+    
+    target_include_directories( basisu PRIVATE ${OpenCL_INCLUDE_DIRS} )
+    set(BASISU_EXTRA_LIBS ${OpenCL_LIBRARIES})
+  endif()
 
 else()
-	# For Windows builds, we use our local copies of the OpenCL import lib and Khronos headers.
-	if (OPENCL)
-		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_OPENCL=1")
-		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_OPENCL=1")	
-		
-		target_include_directories( basisu PRIVATE "OpenCL" )
+  # For Windows builds, we use our local copies of the OpenCL import lib and Khronos headers.
+  if (OPENCL)
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_OPENCL=1")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_OPENCL=1")	
+    
+    target_include_directories( basisu PRIVATE "OpenCL" )
 
-		if ( BUILD_X64 )
-			target_link_libraries( basisu PRIVATE "OpenCL/lib/OpenCL64" )
-		else()
-			target_link_libraries( basisu PRIVATE "OpenCL/lib/OpenCL" )
-		endif()
+    if ( BUILD_X64 )
+      target_link_libraries( basisu PRIVATE "OpenCL/lib/OpenCL64" )
+    else()
+      target_link_libraries( basisu PRIVATE "OpenCL/lib/OpenCL" )
+    endif()
 
-	endif()
-endif()	
+  endif()
+endif()
 
 if (NOT MSVC)
-   target_link_libraries(basisu m pthread ${BASISU_EXTRA_LIBS})
+  target_link_libraries(basisu m pthread ${BASISU_EXTRA_LIBS})
+  target_link_libraries(basisu_encoder m pthread ${BASISU_EXTRA_LIBS})
+  target_link_libraries(basisu_transcoder m pthread ${BASISU_EXTRA_LIBS})
 endif()
 
 if (NOT EMSCRIPTEN)
-	install(TARGETS basisu DESTINATION bin)
-	
-	if (UNIX)
-		if (CMAKE_BUILD_TYPE STREQUAL Release)
-			if (APPLE)
-				add_custom_command(TARGET basisu POST_BUILD COMMAND strip -X -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/basisu)
-			else()
-				add_custom_command(TARGET basisu POST_BUILD COMMAND strip -g -X -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/basisu)
-			endif()
-		endif()
-	endif()
+  include(GNUInstallDirs)
+
+  # Install basisu tool, encoder and transcoder libraries
+  install(TARGETS basisu basisu_encoder basisu_transcoder EXPORT basisu-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  # Install headers for encoder and transcoder manually
+  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/encoder
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/basisu
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp")
+
+  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/transcoder
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/basisu
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp")
+  
+  if (UNIX)
+    if (CMAKE_BUILD_TYPE STREQUAL Release)
+      if (APPLE)
+        add_custom_command(TARGET basisu POST_BUILD COMMAND strip -X -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/basisu)
+      else()
+        add_custom_command(TARGET basisu POST_BUILD COMMAND strip -g -X -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/basisu)
+      endif()
+    endif()
+  endif()
+
+  # Install exports to the share directory
+  install(EXPORT basisu-targets DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/basisu NAMESPACE basisu::)
+
+  # Configure and install the basisu-config file so that later dependencies can find the targets
+  include(CMakePackageConfigHelpers)
+
+  configure_package_config_file(config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/basisu-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/basisu NO_SET_AND_CHECK_MACRO)
+
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/basisu-config.cmake
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/basisu)
 endif()

--- a/config.cmake.in
+++ b/config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/basisu-targets.cmake")


### PR DESCRIPTION
I was investigating adding more support to the meshoptimizer port on vcpkg when I realized I needed meshoptimizer to rely on basisu. Unfortunately it seems like the basisu port on vcpkg has rotted. It points to a fork https://github.com/jherico/basis_universal that has basically rotted and is currently read only. The fork has a few tweaks to the cmake in order to make it more easily consumed by downstream cmake projects, specifically (though not exclusively) through vcpkg. I figured I could take a stab at minimizing those changes and bringing them back into upstream so that it would be easier to update and maintain a vcpkg port of basisu, or just consume it downstream from whatever build system.

I tried to make minimal changes here but I did have to add two new targets so that downstream could rely on just the transcoder or encoder libraries. Both libraries seem to compile properly both with and without cmake's internal BUILD_SHARED_LIBS flag being turned on, so both static and shared libraries can be produced now. I also made sure that the install portion of the script will take care of putting all the headers and libs in the right places and added a config file so that downstream cmake projects can find all the targets via a `find_package` call. 

I'm happy to make edits or add any clarifying comments :)