### PR TITLE
Use snprintf in favor of sprintf

### DIFF
--- a/transcoder/basisu_containers_impl.h
+++ b/transcoder/basisu_containers_impl.h
@@ -49,7 +49,7 @@ namespace basisu
 #ifdef _MSC_VER
             sprintf_s(buf, sizeof(buf), "vector: realloc() failed allocating %u bytes", (uint32_t)desired_size);
 #else
-            sprintf(buf, "vector: realloc() failed allocating %u bytes", (uint32_t)desired_size);
+            snprintf(buf, sizeof(buf), "vector: realloc() failed allocating %u bytes", (uint32_t)desired_size);
 #endif
             fprintf(stderr, "%s", buf);
             abort();
@@ -78,7 +78,7 @@ namespace basisu
 #ifdef _MSC_VER
             sprintf_s(buf, sizeof(buf), "vector: malloc() failed allocating %u bytes", (uint32_t)desired_size);
 #else
-            sprintf(buf, "vector: malloc() failed allocating %u bytes", (uint32_t)desired_size);
+            snprintf(buf, sizeof(buf), "vector: malloc() failed allocating %u bytes", (uint32_t)desired_size);
 #endif
             fprintf(stderr, "%s", buf);
             abort();


### PR DESCRIPTION
On iOS and macOS, `sprintf` is marked as deprecated, causing two warnings when building the transcoder in Xcode. Since the two call sites use a fixed sized buffer, switched to `snprintf`.