### PR TITLE
Use `packed_ull` for values larger than four bytes

### DIFF
--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -280,17 +280,17 @@ namespace basisu
 		pBytes[3] = (uint8_t)(val >> 24U);
 	}
 		
-	// Always little endian 1-8 byte unsigned int
+	// Always little endian 1-4 byte unsigned int
 	template<uint32_t NumBytes>
 	struct packed_uint
 	{
 		uint8_t m_bytes[NumBytes];
 
-		inline packed_uint() { static_assert(NumBytes <= sizeof(uint64_t), "Invalid NumBytes"); }
-		inline packed_uint(uint64_t v) { *this = v; }
+		inline packed_uint() { static_assert(NumBytes <= 4, "Invalid NumBytes"); }
+		inline packed_uint(uint32_t v) { *this = v; }
 		inline packed_uint(const packed_uint& other) { *this = other; }
 						
-		inline packed_uint& operator= (uint64_t v) 
+		inline packed_uint& operator= (uint32_t v)
 		{ 
 			for (uint32_t i = 0; i < NumBytes; i++) 
 				m_bytes[i] = static_cast<uint8_t>(v >> (i * 8)); 
@@ -323,6 +323,58 @@ namespace basisu
 				{
 					return read_le_dword(m_bytes);
 				}
+				default:
+				{
+					assert(0);
+					return 0;
+				}
+			}
+		}
+	};
+
+	// Always little endian 1-8 byte unsigned int
+	template<uint32_t NumBytes>
+	struct packed_ull
+	{
+		uint8_t m_bytes[NumBytes];
+
+		inline packed_ull() { static_assert(NumBytes <= 8, "Invalid NumBytes"); }
+		inline packed_ull(uint64_t v) { *this = v; }
+		inline packed_ull(const packed_ull& other) { *this = other; }
+
+		inline packed_ull& operator= (uint64_t v)
+		{
+			for (uint32_t i = 0; i < NumBytes; i++)
+				m_bytes[i] = static_cast<uint8_t>(v >> (i * 8));
+			return *this;
+		}
+
+		inline packed_ull& operator= (const packed_ull& rhs)
+		{
+			memcpy(m_bytes, rhs.m_bytes, sizeof(m_bytes));
+			return *this;
+		}
+
+		inline operator uint64_t() const
+		{
+			switch (NumBytes)
+			{
+				case 1:
+				{
+					return m_bytes[0];
+				}
+				case 2:
+				{
+					return (m_bytes[1] << 8U) | m_bytes[0];
+				}
+				case 3:
+				{
+					return (m_bytes[2] << 16U) | (m_bytes[1] << 8U) | m_bytes[0];
+				}
+				case 4:
+				{
+					return read_le_dword(m_bytes);
+				}
 				case 5:
 				{
 					uint32_t l = read_le_dword(m_bytes);
@@ -341,13 +393,13 @@ namespace basisu
 					uint32_t h = (m_bytes[6] << 16U) | (m_bytes[5] << 8U) | m_bytes[4];
 					return static_cast<uint64_t>(l) | (static_cast<uint64_t>(h) << 32U);
 				}
-				case 8:  
+				case 8:
 				{
 					uint32_t l = read_le_dword(m_bytes);
 					uint32_t h = read_le_dword(m_bytes + 4);
 					return static_cast<uint64_t>(l) | (static_cast<uint64_t>(h) << 32U);
 				}
-				default: 
+				default:
 				{
 					assert(0);
 					return 0;

--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -8652,7 +8652,7 @@ namespace basist
 			void* pOutput_blocks, uint32_t output_blocks_buf_size_in_blocks_or_pixels,
 			const uint8_t* pCompressed_data, uint32_t compressed_data_length,
 			uint32_t num_blocks_x, uint32_t num_blocks_y, uint32_t orig_width, uint32_t orig_height, uint32_t level_index,
-			uint32_t rgb_offset, uint32_t rgb_length, uint32_t alpha_offset, uint32_t alpha_length,
+			uint64_t rgb_offset, uint32_t rgb_length, uint64_t alpha_offset, uint32_t alpha_length,
 			uint32_t decode_flags,
 			bool basis_file_has_alpha_slices,
 			bool is_video,
@@ -8660,7 +8660,7 @@ namespace basist
 			basisu_transcoder_state* pState,
 			uint32_t output_rows_in_pixels)
 	{
-		if (((uint64_t)rgb_offset + rgb_length) > (uint64_t)compressed_data_length)
+		if ((rgb_offset + rgb_length) > (uint64_t)compressed_data_length)
 		{
 			BASISU_DEVEL_ERROR("basisu_lowlevel_etc1s_transcoder::transcode_image: source data buffer too small (color)\n");
 			return false;
@@ -8668,7 +8668,7 @@ namespace basist
 
 		if (alpha_length)
 		{
-			if (((uint64_t)alpha_offset + alpha_length) > (uint64_t)compressed_data_length)
+			if ((alpha_offset + alpha_length) > (uint64_t)compressed_data_length)
 			{
 				BASISU_DEVEL_ERROR("basisu_lowlevel_etc1s_transcoder::transcode_image: source data buffer too small (alpha)\n");
 				return false;

--- a/transcoder/basisu_transcoder.h
+++ b/transcoder/basisu_transcoder.h
@@ -222,7 +222,7 @@ namespace basist
 			void* pOutput_blocks, uint32_t output_blocks_buf_size_in_blocks_or_pixels,
 			const uint8_t* pCompressed_data, uint32_t compressed_data_length,
 			uint32_t num_blocks_x, uint32_t num_blocks_y, uint32_t orig_width, uint32_t orig_height, uint32_t level_index,
-			uint32_t rgb_offset, uint32_t rgb_length, uint32_t alpha_offset, uint32_t alpha_length,
+			uint64_t rgb_offset, uint32_t rgb_length, uint64_t alpha_offset, uint32_t alpha_length,
 			uint32_t decode_flags = 0,
 			bool basis_file_has_alpha_slices = false,
 			bool is_video = false,
@@ -573,15 +573,15 @@ namespace basist
 		basisu::packed_uint<4> m_dfd_byte_length;
 		basisu::packed_uint<4> m_kvd_byte_offset;
 		basisu::packed_uint<4> m_kvd_byte_length;
-		basisu::packed_uint<8> m_sgd_byte_offset;
-		basisu::packed_uint<8> m_sgd_byte_length;
+		basisu::packed_ull<8> m_sgd_byte_offset;
+		basisu::packed_ull<8> m_sgd_byte_length;
 	};
 
 	struct ktx2_level_index
 	{
-		basisu::packed_uint<8> m_byte_offset;
-		basisu::packed_uint<8> m_byte_length;
-		basisu::packed_uint<8> m_uncompressed_byte_length;
+		basisu::packed_ull<8> m_byte_offset;
+		basisu::packed_ull<8> m_byte_length;
+		basisu::packed_ull<8> m_uncompressed_byte_length;
 	};
 
 	struct ktx2_etc1s_global_data_header


### PR DESCRIPTION
The `packed_uint` `uint32_t()` operator will truncate values exceeding four bytes. In practice, this is probably never a concern for the current `packed_uint<8>` use cases (all KTX2), so this work could be considered a compiler warning fix.

I first attempted to add a `uint64_t()` operator to `packed_uint`, but that caused a bunch of ambiguous operator compiler errors. There's probably a way to implement this change by updating `packed_uint` and doing some fancy templating, but my attempts to do so were unsuccessful (and complex).