### PR TITLE
Added Haiku operating system support

### DIFF
--- a/encoder/basisu_enc.cpp
+++ b/encoder/basisu_enc.cpp
@@ -229,7 +229,7 @@ namespace basisu
 	{
 		QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(pTicks));
 	}
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__EMSCRIPTEN__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__EMSCRIPTEN__) || defined(__HAIKU__)
 #include <sys/time.h>
 	inline void query_counter(timer_ticks* pTicks)
 	{


### PR DESCRIPTION
Adding one defined(__HAIKU__) definition allows the package to build and run on the Haiku operating system.  Since Haiku is an early POSIX implementer and shares a lot of other code with BSD, it shouldn't be too objectionable to merge.