### PR TITLE
SIMD: disable compile time checks

### DIFF
--- a/encoder/basisu_kernels_sse.cpp
+++ b/encoder/basisu_kernels_sse.cpp
@@ -22,22 +22,6 @@
 #include <intrin.h>
 #endif
 
-#if !defined(_MSC_VER)
-	#if __AVX__ || __AVX2__ || __AVX512F__
-		#error Please check your compiler options
-	#endif
-	
-	#if CPPSPMD_SSE2
-		#if __SSE4_1__ || __SSE3__ || __SSE4_2__ || __SSSE3__
-			#error SSE4.1/SSE3/SSE4.2/SSSE3 cannot be enabled to use this file
-		#endif
-	#else
-		#if !__SSE4_1__ || !__SSE3__ || !__SSSE3__
-			#error Please check your compiler options
-		#endif
-	#endif
-#endif
-
 #include "cppspmd_sse.h"
 
 #include "cppspmd_type_aliases.h"


### PR DESCRIPTION
SSE4.1 support is checked at runtime, so compile time checks are redundant at best and harmful when compiling for a different machine.

Further more, a logic error prevented the use of SSE4.1 on systems with any version of AVX available. This is fixed now.

Fixes: https://github.com/BinomialLLC/basis_universal/issues/342
