### PR TITLE
Allow building against external zstd library (for non-CMake builds)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ add_executable(basisu ${BASISU_SRC_LIST})
 
 if (ZSTD)
 	target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
+	target_include_directories(basisu PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/zstd)
 else()
 	target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=0)
 endif()

--- a/encoder/basisu_comp.cpp
+++ b/encoder/basisu_comp.cpp
@@ -28,7 +28,7 @@
 #endif
 
 #if BASISD_SUPPORT_KTX2_ZSTD
-#include "../zstd/zstd.h"
+#include <zstd.h>
 #endif
 
 // Set to 1 to disable the mipPadding alignment workaround (which only seems to be needed when no key-values are written at all)

--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -155,7 +155,7 @@
    // If BASISD_SUPPORT_KTX2_ZSTD is 0, UASTC files compressed with Zstd cannot be loaded.
 	#if BASISD_SUPPORT_KTX2_ZSTD
 		// We only use two Zstd API's: ZSTD_decompress() and ZSTD_isError()
-		#include "../zstd/zstd.h"
+		#include <zstd.h>
 	#endif
 #endif
 


### PR DESCRIPTION
Rebase of @ondys' #228 with one missed include changed too.
Supersedes #228. (This PR can be closed if #228 is updated with the `transcoder` change.)

We have the same need in the Godot project, also with a non-CMake build (relevant build file for SCons: https://github.com/godotengine/godot/blob/master/modules/basis_universal/SCsub).

CMake users may also want to have an easy way to use their own zstd implementation, but for this PR I followed @ondys' steps to do the minimal changes needed by existing downstream projects which shouldn't break the workflow for the main app.