### PR TITLE
Make sure unpacked.m_common_pattern is initialized

### DIFF
--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -12170,6 +12170,7 @@ namespace basist
 			return false;
 
 		unpacked.m_mode = mode;
+		unpacked.m_common_pattern = 0;
 
 		uint32_t bit_ofs = g_uastc_mode_huff_codes[mode][1];
 


### PR DESCRIPTION
In uastc modes where unpacked.m_common_pattern is not used, it's still read and passed by value to two functions (where it won't be used). This confuses my company's code analysis tools. Could we make sure we already initialize this member variable? Thx