### PR TITLE
fix build for Haiku

### DIFF
--- a/encoder/basisu_enc.cpp
+++ b/encoder/basisu_enc.cpp
@@ -242,7 +242,11 @@ namespace basisu
 		*pTicks = 1000000;
 	}
 #elif defined(__GNUC__)
+#ifdef __HAIKU__
+#include <sys/time.h>
+#else
 #include <sys/timex.h>
+#endif
 	inline void query_counter(timer_ticks* pTicks)
 	{
 		struct timeval cur_time;


### PR DESCRIPTION
Hello,
this patch fixes the build on Haiku. sys/timex.h seems to be linux-specific,
on Haiku you have to use time.h
Everything seems to work, running ./basisu -test seems to run fine