### PR TITLE
feat: support -output_path when use unpack

### DIFF
--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -2552,6 +2552,14 @@ static bool unpack_and_validate_mode(command_line_params &opts)
 		std::string base_filename;
 		string_split_path(pInput_filename, nullptr, nullptr, &base_filename, nullptr);
 
+		if (opts.m_output_path.size()) {
+			if (!create_directory_if_not_exists(opts.m_output_path)) {
+				return false;
+			}
+
+			string_combine_path(base_filename, opts.m_output_path.c_str(), base_filename.c_str());
+		}
+
 		uint8_vec file_data;
 		if (!basisu::read_file_to_vec(pInput_filename, file_data))
 		{

--- a/encoder/basisu_enc.cpp
+++ b/encoder/basisu_enc.cpp
@@ -33,6 +33,13 @@
 #include <windows.h>
 #endif
 
+#include <filesystem>
+#if defined(_WIN32)
+namespace fs = std::filesystem;
+#else
+namespace fs = std::__fs::filesystem;
+#endif
+
 namespace basisu
 {
 	uint64_t interval_timer::g_init_ticks, interval_timer::g_freq;
@@ -505,7 +512,29 @@ namespace basisu
 						
 		return status;
 	}
-		
+
+	bool create_directory_if_not_exists(std::string &dir) {
+		fs::path dir_path(dir);
+
+		try {
+			if (!fs::exists(dir_path)) {
+				if (fs::create_directories(dir_path)) {
+					// Directory created
+				} else {
+					error_printf("Failed to create directory: \"%s\"\n", dir.c_str());
+					return false;
+				}
+			} else if (!fs::is_directory(dir_path)) {
+				error_printf("Path exists but is not a directory: \"%s\"\n", dir.c_str());
+				return false;
+			}
+			return true;
+		} catch (const fs::filesystem_error& e) {
+			error_printf("Filesystem error: \"%s\"\n", e.what());
+			return false;
+		}
+	}
+
 	bool read_file_to_vec(const char* pFilename, uint8_vec& data)
 	{
 		FILE* pFile = nullptr;

--- a/encoder/basisu_enc.h
+++ b/encoder/basisu_enc.h
@@ -3274,7 +3274,9 @@ namespace basisu
 
 	bool save_png(const char* pFilename, const image& img, uint32_t image_save_flags = 0, uint32_t grayscale_comp = 0);
 	inline bool save_png(const std::string &filename, const image &img, uint32_t image_save_flags = 0, uint32_t grayscale_comp = 0) { return save_png(filename.c_str(), img, image_save_flags, grayscale_comp); }
-	
+
+	bool create_directory_if_not_exists(std::string &dir);
+
 	bool read_file_to_vec(const char* pFilename, uint8_vec& data);
 	
 	bool write_data_to_file(const char* pFilename, const void* pData, size_t len);


### PR DESCRIPTION
Use `output_path` to specify a directory when use unpack mode, like:

```shell
basisu test.ktx2 -output_path dist
```

filesystem dependence on C++17. And just test on my Mac, there is no other platform device.