### PR TITLE
Fix gcc's calloc-transposed-args warning

### DIFF
--- a/encoder/3rdparty/tinyexr.h
+++ b/encoder/3rdparty/tinyexr.h
@@ -4928,7 +4928,7 @@ static int DecodeTiledLevel(EXRImage* exr_image, const EXRHeader* exr_header,
   }
 #endif
   exr_image->tiles = static_cast<EXRTile*>(
-    calloc(sizeof(EXRTile), static_cast<size_t>(num_tiles)));
+    calloc(static_cast<size_t>(num_tiles), sizeof(EXRTile)));
 
 #if TINYEXR_HAS_CXX11 && (TINYEXR_USE_THREAD > 0)
   std::vector<std::thread> workers;


### PR DESCRIPTION
calloc takes sizeof as the second argument.