### PR TITLE
Fix ambiguous calls to `safe_shift_left()` in `basisu_containers.h`

### DIFF
--- a/transcoder/basisu_containers.h
+++ b/transcoder/basisu_containers.h
@@ -3349,7 +3349,7 @@ namespace basisu
 
 		inline size_t hash_key(const Key& k) const
 		{
-			assert((safe_shift_left(1ULL, (SIZE_T_BITS - m_hash_shift))) == m_values.size());
+			assert((safe_shift_left(static_cast<uint64_t>(1), (SIZE_T_BITS - m_hash_shift))) == m_values.size());
 
 			// Fibonacci hashing
 			if (SIZE_T_BITS == 32)
@@ -3433,7 +3433,7 @@ namespace basisu
 				return false;
 
 			new_map.m_hash_shift = SIZE_T_BITS - helpers::floor_log2i((uint64_t)new_hash_size);
-			assert(new_hash_size == safe_shift_left(1ULL, SIZE_T_BITS - new_map.m_hash_shift));
+			assert(new_hash_size == safe_shift_left(static_cast<uint64_t>(1), SIZE_T_BITS - new_map.m_hash_shift));
 
 			new_map.m_grow_threshold = std::numeric_limits<size_t>::max();
 


### PR DESCRIPTION
When updating `basis_universal` to version 1.60 in Godot (https://github.com/godotengine/godot/pull/103968), I came across a compiler error about function call ambiguity.

This PR resolves said compile-time ambiguities. The issue occurs because the literal `1ULL` can be converted to both `uint32_t` and `uint64_t`, causing two overloads of `safe_shift_left()` (one for each type) to be viable.

I've explicitly cast the literal to `uint64_t` to fix the ambiguity.
