### PR TITLE
CMake: Fixed VS build by setting the C++ standard to 17 for "if constexpr".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@
 # It should also work without this option, but we do not test with it.
 cmake_minimum_required(VERSION 3.5)
 
-project(basisu)
+project(basisu C CXX)
+set(CMAKE_CXX_STANDARD 17)
 option(STATIC "static linking" FALSE)
 option(SAN "sanitize" FALSE)
 


### PR DESCRIPTION
C++ only formally got "if constexpr" in C++17.  VC++ enforces this, and so when using basis_universal with Visual Studio in its CMake mode, the build is broken.  This fixes the build.