### PR TITLE
Fix CMake Unity builds

### DIFF
--- a/transcoder/basisu_astc_helpers.h
+++ b/transcoder/basisu_astc_helpers.h
@@ -1,6 +1,5 @@
 // basisu_astc_helpers.h
 // Be sure to define ASTC_HELPERS_IMPLEMENTATION somewhere to get the implementation, otherwise you only get the header.
-#pragma once
 #ifndef BASISU_ASTC_HELPERS_HEADER
 #define BASISU_ASTC_HELPERS_HEADER
 


### PR DESCRIPTION
transcoder/basisu_astc_helpers.h has a pragma once, but it is also an implementation header (when ASTC_HELPERS_IMPLEMENTATION is defined).

pragma once is not necessary here as the header has a separate ifdef guard, and it blocks attempts to compile Basis as a CMake Unity build (CMAKE_UNITY_BUILD=ON) or as a single-translation unit non-CMake build if the helpers header has been included earlier in the TU, as the second inclusion with implementation defined doesn't actually include the header.