### PR TITLE
Fix: bring back -O3 in LINK_FLAGS for 150kB smaller JS+WASM build

### DIFF
--- a/webgl/transcoder/CMakeLists.txt
+++ b/webgl/transcoder/CMakeLists.txt
@@ -64,5 +64,5 @@ if (EMSCRIPTEN)
   set_target_properties(basis_transcoder.js PROPERTIES
       OUTPUT_NAME "basis_transcoder"
       SUFFIX ".js"
-      LINK_FLAGS "--bind -s ALLOW_MEMORY_GROWTH=1 -s MALLOC=emmalloc -s MODULARIZE=1 -s EXPORT_NAME=BASIS -s ASSERTIONS=0 -s EXPORTED_RUNTIME_METHODS=['HEAP8']")
+      LINK_FLAGS "--bind -s ALLOW_MEMORY_GROWTH=1 -O3 -s MALLOC=emmalloc -s MODULARIZE=1 -s EXPORT_NAME=BASIS -s ASSERTIONS=0 -s EXPORTED_RUNTIME_METHODS=['HEAP8']")
 endif()


### PR DESCRIPTION
This PR re-adds -O3 for linking the transcoder.

There seems to be a considerable size increase in basis from 1.50 (53 KB JS + 527 KB WASM) to 1.60 (106 KB JS + 669 KB WASM).

When looking at the file history, I found 1.50 had used the -O3 link flag and it was removed.
Adding it back minifies the JS, and brings it back down to 53kB. It also reduces the size of the WASM to 620 KB.

Was there a reason for this change or is it an oversight?