### PR TITLE
Use C++17 `[[fallthrough]]` to make intentional fallthroughs explicit

### DIFF
--- a/encoder/3rdparty/android_astc_decomp.cpp
+++ b/encoder/3rdparty/android_astc_decomp.cpp
@@ -836,28 +836,17 @@ void decodeISETritBlock (ISEDecodedResult* dst, int numValues, BitAccessStream& 
     m[4]            = data.getNext(numBits);
     deUint32 T7     = data.getNext(1);
 
-#ifndef __EMSCRIPTEN__
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough="            
-#endif  
-#endif
     switch (numValues)
     {
         // \note Fall-throughs.
-        case 1: T23     = 0;
-        case 2: T4      = 0;
-        case 3: T56     = 0;
-        case 4: T7      = 0;
+        case 1: T23     = 0; [[fallthrough]];
+        case 2: T4      = 0; [[fallthrough]];
+        case 3: T56     = 0; [[fallthrough]];
+        case 4: T7      = 0; [[fallthrough]];
         case 5: break;
         default:
             DE_ASSERT(false);
     }
-#ifndef __EMSCRIPTEN__
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif 
-#endif
 
     const deUint32 T = (T7 << 7) | (T56 << 5) | (T4 << 4) | (T23 << 2) | (T01 << 0);
 
@@ -902,26 +891,15 @@ void decodeISEQuintBlock (ISEDecodedResult* dst, int numValues, BitAccessStream&
     m[2]            = data.getNext(numBits);
     deUint32 Q56    = data.getNext(2);
 
-#ifndef __EMSCRIPTEN__
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough="            
-#endif  
-#endif
     switch (numValues)
     {
         // \note Fall-throughs.
-        case 1: Q34     = 0;
-        case 2: Q56     = 0;
+        case 1: Q34     = 0; [[fallthrough]];
+        case 2: Q56     = 0; [[fallthrough]];
         case 3: break;
         default:
             DE_ASSERT(false);
     }
-#ifndef __EMSCRIPTEN__
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif 
-#endif
 
     const deUint32 Q = (Q56 << 5) | (Q34 << 3) | (Q012 << 0);
 


### PR DESCRIPTION
Just a small cleanup that removes the need for a GCC-specific pragma.

Clang/Emscripten would also generate this warning BTW if `-Wimplicit-fallthrough` was passed explicitly (it doesn't seem to be enabled by `-Wall -Wextra`). From a quick test it can be silenced for both GCC and Clang-derived compilers by ignoring `-Wimplicit-fallthrough` instead of `-Wimplicit-fallthrough=` (note the trailing `=`). But here using `[[fallthrough]]` is IMO better as it makes the intention explicit for all compilers.