### PR TITLE
Fix C++20 warning for deprecated enum operation

### DIFF
--- a/encoder/basisu_math.h
+++ b/encoder/basisu_math.h
@@ -45,10 +45,7 @@ namespace bu_math
 	{
 	public:
 		typedef T scalar_type;
-		enum
-		{
-			num_elements = N
-		};
+		static constexpr uint32_t num_elements = N;
 
 		inline vec()
 		{
@@ -1196,15 +1193,8 @@ namespace bu_math
 	{
 	public:
 		typedef T scalar_type;
-		static const uint32_t num_rows = R;
-		static const uint32_t num_cols = C;
-#if 0
-		enum
-		{
-			num_rows = R,
-			num_cols = C
-		};
-#endif
+		static constexpr uint32_t num_rows = R;
+		static constexpr uint32_t num_cols = C;
 
 		typedef vec<R, T> col_vec;
 		typedef vec < (R > 1) ? (R - 1) : 0, T > subcol_vec;
@@ -1875,10 +1865,10 @@ namespace bu_math
 		static inline subcol_vec transform_point(const subcol_vec& a, const matrix& b)
 		{
 			subcol_vec result(0);
-			for (int r = 0; r < static_cast<int>(R); r++)
+			for (uint32_t r = 0; r < R; r++)
 			{
 				const T s = (r < subcol_vec::num_elements) ? a[r] : 1.0f;
-				for (int c = 0; c < static_cast<int>(C - 1); c++)
+				for (uint32_t c = 0; c < (C - 1); c++)
 					result[c] += b[r][c] * s;
 			}
 			return result;
@@ -1931,10 +1921,10 @@ namespace bu_math
 		{
 			static_assert(R == C);
 			subcol_vec result(0);
-			for (int r = 0; r < R; r++)
+			for (uint32_t r = 0; r < R; r++)
 			{
 				const T s = (r < subcol_vec::num_elements) ? a[r] : 1.0f;
-				for (int c = 0; c < (C - 1); c++)
+				for (uint32_t c = 0; c < (C - 1); c++)
 					result[c] += b[c][r] * s;
 			}
 			return result;


### PR DESCRIPTION
Small cleanup to circumvent repos targeting C++20 and above from having to suppress warnings over deprecated enum operations. The offending area was `X::num_rows + Y::num_rows` in the template declaration of `matrix_combine_vertically`, resulting in these warnings:
- **GCC**: `deprecated-enum-enum-conversion`
- **Clang**: `deprecated-anon-enum-enum-conversion`
- **MSVC**: `5054` (operator '*': deprecated between enumerations of different types)

This was addressed by converting the offending file's anonymous enums to `static constexpr` variables, which is the recommended way to declare scoped constants in C++17 and above.