### PR TITLE
Fix missing cfloat include in basisu_astc_hdr_6x6_enc.cpp

### DIFF
--- a/encoder/basisu_astc_hdr_6x6_enc.cpp
+++ b/encoder/basisu_astc_hdr_6x6_enc.cpp
@@ -13,6 +13,7 @@
 #include "3rdparty/android_astc_decomp.h"
 
 #include <array>
+#include <cfloat>
 
 using namespace basisu;
 using namespace buminiz;


### PR DESCRIPTION
Add `#include <cfloat>` to provide the `DBL_MAX` constant.

Tested with:
- GCC 11.4.0 on Ubuntu 22.04
- CMAKE_BUILD_TYPE=Release
- OPENCL=TRUE