### PR TITLE
Fix C++20 `-Wdeprecated-enum-enum-conversion` warning by using integer types for matrix::num_rows and num_cols

### DIFF
--- a/encoder/basisu_math.h
+++ b/encoder/basisu_math.h
@@ -1130,12 +1130,12 @@ namespace bu_math
 	template <class X, class Y, class Z>
 	Z& matrix_mul_helper(Z& result, const X& lhs, const Y& rhs)
 	{
-		static_assert((int)Z::num_rows == (int)X::num_rows);
-		static_assert((int)Z::num_cols == (int)Y::num_cols);
-		static_assert((int)X::num_cols == (int)Y::num_rows);
+		static_assert(Z::num_rows == X::num_rows);
+		static_assert(Z::num_cols == Y::num_cols);
+		static_assert(X::num_cols == Y::num_rows);
 		assert(((void*)&result != (void*)&lhs) && ((void*)&result != (void*)&rhs));
-		for (int r = 0; r < X::num_rows; r++)
-			for (int c = 0; c < Y::num_cols; c++)
+		for (uint32_t r = 0; r < X::num_rows; r++)
+			for (uint32_t c = 0; c < Y::num_cols; c++)
 			{
 				typename Z::scalar_type s = lhs(r, 0) * rhs(0, c);
 				for (uint32_t i = 1; i < X::num_cols; i++)
@@ -1148,12 +1148,12 @@ namespace bu_math
 	template <class X, class Y, class Z>
 	Z& matrix_mul_helper_transpose_lhs(Z& result, const X& lhs, const Y& rhs)
 	{
-		static_assert((int)Z::num_rows == (int)X::num_cols);
-		static_assert((int)Z::num_cols == (int)Y::num_cols);
-		static_assert((int)X::num_rows == (int)Y::num_rows);
+		static_assert(Z::num_rows == X::num_cols);
+		static_assert(Z::num_cols == Y::num_cols);
+		static_assert(X::num_rows == Y::num_rows);
 		assert(((void*)&result != (void*)&lhs) && ((void*)&result != (void*)&rhs));
-		for (int r = 0; r < X::num_cols; r++)
-			for (int c = 0; c < Y::num_cols; c++)
+		for (uint32_t r = 0; r < X::num_cols; r++)
+			for (uint32_t c = 0; c < Y::num_cols; c++)
 			{
 				typename Z::scalar_type s = lhs(0, r) * rhs(0, c);
 				for (uint32_t i = 1; i < X::num_rows; i++)
@@ -1166,12 +1166,12 @@ namespace bu_math
 	template <class X, class Y, class Z>
 	Z& matrix_mul_helper_transpose_rhs(Z& result, const X& lhs, const Y& rhs)
 	{
-		static_assert((int)Z::num_rows == (int)X::num_rows);
-		static_assert((int)Z::num_cols == (int)Y::num_rows);
-		static_assert((int)X::num_cols == (int)Y::num_cols);
+		static_assert(Z::num_rows == X::num_rows);
+		static_assert(Z::num_cols == Y::num_rows);
+		static_assert(X::num_cols == Y::num_cols);
 		assert(((void*)&result != (void*)&lhs) && ((void*)&result != (void*)&rhs));
-		for (int r = 0; r < X::num_rows; r++)
-			for (int c = 0; c < Y::num_rows; c++)
+		for (uint32_t r = 0; r < X::num_rows; r++)
+			for (uint32_t c = 0; c < Y::num_rows; c++)
 			{
 				typename Z::scalar_type s = lhs(r, 0) * rhs(c, 0);
 				for (uint32_t i = 1; i < X::num_cols; i++)
@@ -2141,7 +2141,7 @@ namespace bu_math
 		static inline matrix make_tensor_product_matrix(const row_vec& v, const row_vec& w)
 		{
 			matrix ret;
-			for (int r = 0; r < num_rows; r++)
+			for (uint32_t r = 0; r < num_rows; r++)
 				ret[r] = row_vec::mul_components(v.broadcast(r), w);
 			return ret;
 		}


### PR DESCRIPTION
Hi! This fixes a `-Wdeprecated-enum-enum-conversion` warning on GCC and Clang we ran into when compiling basisu's files inside a C++20 project. Basisu's CMakeLists.txt specifies C++17, but this can be reproduced without a custom CMake script by running

```
g++ -O3 -DNDEBUG -std=c++20 -o temp.o -c basis_universal/encoder/basisu_astc_hdr_6x6_enc.cpp
```

This produces the following warning:

```
in file included from basis_universal/encoder/basisu_enc.h:4310,
                 from basis_universal/encoder/basisu_astc_hdr_6x6_enc.h:3,
                 from basis_universal/encoder/basisu_astc_hdr_6x6_enc.cpp:2:
basis_universal/encoder/basisu_math.h: In instantiation of ‘bu_math::matrix<(X::num_rows * Y::num_rows), (X::num_cols * Y::num_cols), typename X::scalar_type> bu_math::matrix_kronecker_product(const X&, const Y&) [with X = matrix<2, 2, float>; Y = matrix<1, 2, float>; typename X::scalar_type = float]’:
basis_universal/encoder/basisu_math.h:2411:57:   required from here
basis_universal/encoder/basisu_math.h:2362:60: warning: arithmetic between different enumeration types ‘bu_math::matrix<2, 2, float>::<unnamed enum>’ and ‘bu_math::matrix<1, 2, float>::<unnamed enum>’ is deprecated [-Wdeprecated-enum-enum-conversion]
 2362 |         template<typename X, typename Y> matrix<X::num_rows* Y::num_rows, X::num_cols* Y::num_cols, typename X::scalar_type> matrix_kronecker_product(const X& a, const Y& b)
      |                                                    ~~~~~~~~^~~~~~~~~~~~~
```

Previously, `num_rows` and `num_cols` were members of an anonymous union within each templated matrix type:

```cpp
	template <uint32_t R, uint32_t C, typename T>
	class matrix
	{
	public:
		typedef T scalar_type;
		enum
		{
			num_rows = R,
			num_cols = C
		};
                ...
```

This meant that arithmetic operations between `num_rows` and `num_cols` of different matrix types were technically implicitly converting between different types, resulting in the warning above. Changing the types of `num_rows` and `num_cols` to `static const uint32_t` fixes this.

Thank you!