### PR TITLE
Switch from using "CMAKE_SOURCE_DIR" to CMAKE_CURRENT_SOURCE_DIR for "basisu.manifest".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,9 +226,9 @@ if(EXAMPLES)
 endif()
 
 #if (MSVC)
-    target_sources(basisu PRIVATE "${CMAKE_SOURCE_DIR}/basisu.manifest")
+    target_sources(basisu PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/basisu.manifest")
 	if(EXAMPLES)
-    	target_sources(examples PRIVATE "${CMAKE_SOURCE_DIR}/basisu.manifest")
+    	target_sources(examples PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/basisu.manifest")
 	endif()
 #endif()
 


### PR DESCRIPTION
Hello,
There was a change that broke my usage of basis_universal as a submodule since it tries to locate the manifest file from the root cmake directory. I have all third party code in a sub folder. This PR makes it so it works when basis_universal is used as the root project and as a subproject.