### PR TITLE
Add TexturePacker link to External Tool Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ checking tool (https://reuse.software/). See the `.reuse` subdirectory.
 External Tool Links
 -------------------
 
+[TexturePacker](https://www.codeandweb.com/texturepacker) - Packs sprite sheets for games, supports Basis Universal output format.
+
 [Online .EXR HDR Image File Viewer](https://viewer.openhdr.org/)
 
 [Windows HDR + WCG Image Viewer](https://13thsymphony.github.io/hdrimageviewer/) - A true HDR image viewer for Windows. Also see [the github repo](https://github.com/13thsymphony/HDRImageViewer).


### PR DESCRIPTION
Added TexturePacker as external tool.
It supports packing sprite sheets and converting images to basisu.