### PR TITLE
Fix building on NetBSD

### DIFF
--- a/encoder/basisu_enc.h
+++ b/encoder/basisu_enc.h
@@ -4311,7 +4311,7 @@ namespace basisu
 	// Positive, negative, or denormals. No NaN or Inf. Clamped to MAX_HALF_FLOAT.
 	inline basist::half_float fast_float_to_half_trunc_no_nan_or_inf(float f)
 	{
-		assert(!isnan(f) && !isinf(f));
+		assert(!std::isnan(f) && !std::isinf(f));
 
 		// Sutract 112 from the exponent, to change the bias from 127 to 15.
 		static const fu32 g_f_to_h{ 0x7800000 };
@@ -4325,7 +4325,7 @@ namespace basisu
 
 	inline basist::half_float fast_float_to_half_trunc_no_clamp_neg_nan_or_inf(float f)
 	{
-		assert(!isnan(f) && !isinf(f));
+		assert(!std::isnan(f) && !std::isinf(f));
 		assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
 
 		// Sutract 112 from the exponent, to change the bias from 127 to 15.
@@ -4340,7 +4340,7 @@ namespace basisu
 
 	inline basist::half_float fast_float_to_half_no_clamp_neg_nan_or_inf(float f)
 	{
-		assert(!isnan(f) && !isinf(f));
+		assert(!std::isnan(f) && !std::isinf(f));
 		assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
 
 		// Sutract 112 from the exponent, to change the bias from 127 to 15.

--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -22119,7 +22119,7 @@ namespace basist
 
 		static BASISU_FORCE_INLINE basist::half_float fast_float_to_half_no_clamp_neg_nan_or_inf(float f)
 		{
-			assert(!isnan(f) && !isinf(f));
+			assert(!std::isnan(f) && !std::isinf(f));
 			assert((f >= 0.0f) && (f <= basist::MAX_HALF_FLOAT));
 
 			// Sutract 112 from the exponent, to change the bias from 127 to 15.


### PR DESCRIPTION
While working on https://github.com/godotengine/godot/pull/114233 I found that this prevented building on NetBSD 10.1. I don't remember as to why this is the case but the Godot CI builds on all other supported platforms were successful and there are already instances of `std::isinf` and `std::isnan` in the codebase so this just makes them all use the std namespace.