### PR TITLE
Fix Haiku build

### DIFF
--- a/encoder/basisu_enc.cpp
+++ b/encoder/basisu_enc.cpp
@@ -289,7 +289,7 @@ namespace basisu
 	{
 		QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(pTicks));
 	}
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__EMSCRIPTEN__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__EMSCRIPTEN__) || defined(__HAIKU__)
 #include <sys/time.h>
 	inline void query_counter(timer_ticks* pTicks)
 	{


### PR DESCRIPTION
Basisu build on [Haiku](https://www.haiku-os.org/) OS currently fails because it ends up wanting `timex.h`, changing that to `time.h` fixes it.

As far as I can tell, the tool works just fine on the OS, I've been using it while compiling Warzone 2100 for the platform and that game's textures are processed properly and display as they should in-game.

EDIT: duplicate of #372, sorry