### PR TITLE
Fix BASISU_ZSTD=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,11 +290,23 @@ set(ENCODER_LIB_SRC_LIST
 )
 
 if (BASISU_ZSTD)
-    set(ENCODER_LIB_SRC_LIST ${ENCODER_LIB_SRC_LIST} zstd/zstd.c)
+    # Full zstd library (encoder + decoder) for the encoder
+    add_library(basisu_zstd_encoder STATIC zstd/zstd.c)
+    target_include_directories(basisu_zstd_encoder PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/zstd)
+    set_property(TARGET basisu_zstd_encoder PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+    # Decoder-only zstd library for transcoder-only targets (smaller footprint)
+    add_library(basisu_zstd_decoder STATIC zstd/zstddeclib.c)
+    target_include_directories(basisu_zstd_decoder PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/zstd)
+    set_property(TARGET basisu_zstd_decoder PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
 # Create the static library
 add_library(basisu_encoder STATIC ${ENCODER_LIB_SRC_LIST})
+
+if (BASISU_ZSTD)
+    target_link_libraries(basisu_encoder PUBLIC basisu_zstd_encoder)
+endif()
 
 # Create the basisu executable and link against the static library
 add_executable(basisu basisu_tool.cpp)
@@ -308,7 +320,10 @@ if(BASISU_EXAMPLES)
     add_executable(example_capi example_capi/example_capi.c encoder/basisu_wasm_api.cpp encoder/basisu_wasm_transcoder_api.cpp)
     target_link_libraries(example_capi PRIVATE basisu_encoder)
     
-    add_executable(example_transcoding example_transcoding/example_transcoding.cpp example_transcoding/utils.cpp zstd/zstddeclib.c transcoder/basisu_transcoder.cpp)
+    add_executable(example_transcoding example_transcoding/example_transcoding.cpp example_transcoding/utils.cpp transcoder/basisu_transcoder.cpp)
+    if (BASISU_ZSTD)
+        target_link_libraries(example_transcoding PRIVATE basisu_zstd_decoder)
+    endif()
 endif() 
 
 if (BASISU_BUILD_WASM)
@@ -343,7 +358,7 @@ if (BASISU_BUILD_WASM)
         
     endif()
 
-    # 256 MB initial, 3.5 GB max  safe defaults for BasisU
+    # 256 MB initial, 3.5 GB max safe defaults for BasisU
     target_link_options(basisu PRIVATE
         -Wl,--initial-memory=268435456
         -Wl,--max-memory=3758096384
@@ -583,8 +598,11 @@ if (BASISU_BUILD_WASM)
 
     add_executable(${BASISU_TRANSCODER_WASM_OUTPUT_NAME} 
         ${CMAKE_CURRENT_SOURCE_DIR}/encoder/basisu_wasm_transcoder_api.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/transcoder/basisu_transcoder.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/zstd/zstddeclib.c)
+        ${CMAKE_CURRENT_SOURCE_DIR}/transcoder/basisu_transcoder.cpp)
+
+    if (BASISU_ZSTD)
+        target_link_libraries(${BASISU_TRANSCODER_WASM_OUTPUT_NAME} PRIVATE basisu_zstd_decoder)
+    endif()
             
     set_target_properties(${BASISU_TRANSCODER_WASM_OUTPUT_NAME} PROPERTIES SUFFIX ".wasm")
 
@@ -647,8 +665,11 @@ if (BASISU_BUILD_PYTHON AND NOT BASISU_BUILD_WASM)
         python/basisu_transcoder_pybind11.cpp
         encoder/basisu_wasm_transcoder_api.cpp  
         transcoder/basisu_transcoder.cpp
-        zstd/zstddeclib.c
     )
+    
+    if (BASISU_ZSTD)
+        target_link_libraries(basisu_transcoder_python PRIVATE basisu_zstd_decoder)
+    endif()
     
     # Ensure PIC ONLY for this target
     set_property(TARGET basisu_transcoder_python PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/encoder/basisu_astc_ldr_encode.cpp
+++ b/encoder/basisu_astc_ldr_encode.cpp
@@ -24,7 +24,7 @@
 #endif
 
 #if BASISU_ASTC_LDR_SUPPORT_ZSTD
-#include "../zstd/zstd.h"
+#include "zstd.h"
 #endif
 
 namespace basisu {

--- a/encoder/basisu_comp.cpp
+++ b/encoder/basisu_comp.cpp
@@ -34,7 +34,7 @@
 #endif
 
 #if BASISD_SUPPORT_KTX2_ZSTD
-#include "../zstd/zstd.h"
+#include "zstd.h"
 #endif
 
 // Set to 1 to disable the mipPadding alignment workaround (which only seems to be needed when no key-values are written at all)

--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -174,7 +174,7 @@
    // If BASISD_SUPPORT_KTX2_ZSTD is 0, UASTC files compressed with Zstd cannot be loaded.
 	#if BASISD_SUPPORT_KTX2_ZSTD
 		// We only use two Zstd API's: ZSTD_decompress() and ZSTD_isError()
-		#include "../zstd/zstd.h"
+		#include "zstd.h"
 	#endif
 #endif
 


### PR DESCRIPTION
Fixes support for `-DBASISU_ZSTD=OFF`, which is useful for projects where assets already have compression applied to them to avoid redundancy (or in web deployments where server typically compresses binary files already). This was broken it seems with `basisu_astc_ldr_encode.cpp` unconditionally including zstd where previously only KTX2 code paths conditionally included it.

Also treat zstd as a separate libraries (encoder and decoder-only variants) with its own include path vs hard-coded relative path. This makes it easier for dependent projects to use their own version of zstd to avoids conflicts.