### PR TITLE
Fix c++20 warning "enum to enum arithmetic deprecated."

### DIFF
--- a/transcoder/basisu_transcoder_internal.h
+++ b/transcoder/basisu_transcoder_internal.h
@@ -2123,7 +2123,7 @@ namespace basist
 		enum { TABLE_BITS = 8 };               // 256..1024 entries typical (8..10)
 		enum { TABLE_SIZE = 1 << TABLE_BITS };
 		enum { MANT_BITS = 23 };
-		enum { FRAC_BITS = MANT_BITS - TABLE_BITS };
+		enum { FRAC_BITS = (int)MANT_BITS - (int)TABLE_BITS };
 		enum { FRAC_MASK = (1u << FRAC_BITS) - 1u };
 
 		extern bool g_initialized;


### PR DESCRIPTION
We hit this because we have a test app that includes `basisu_transcoder_internal.h` and uses c++20.