### PR TITLE
Chnage non-ascii hyphens to regular hyphens.

### DIFF
--- a/encoder/basisu_astc_ldr_common.cpp
+++ b/encoder/basisu_astc_ldr_common.cpp
@@ -878,7 +878,7 @@ namespace astc_ldr
 	}
 #endif
 
-	// TODO: Try two-step Lanczos iteration/Rayleigh–Ritz approximation in a 2-dimensional Krylov subspace method vs. power method.
+	// TODO: Try two-step Lanczos iteration/Rayleigh-Ritz approximation in a 2-dimensional Krylov subspace method vs. power method.
 	static vec4F calc_pca_4D(uint32_t num_pixels, const vec4F* pPixels, const vec4F& mean_f)
 	{
 		float m00 = 0, m01 = 0, m02 = 0, m03 = 0;

--- a/transcoder/basisu_transcoder_internal.h
+++ b/transcoder/basisu_transcoder_internal.h
@@ -1758,7 +1758,7 @@ namespace basist
 					return (int)std::round(d / (float)L);
 				}
 
-				// L = quant step, alpha in [0,1.2] (typical 0.7–0.85)
+				// L = quant step, alpha in [0,1.2] (typical 0.7-0.85)
 				if (L <= 0) 
 					return 0;
 
@@ -2123,7 +2123,7 @@ namespace basist
 		enum { TABLE_BITS = 8 };               // 256..1024 entries typical (8..10)
 		enum { TABLE_SIZE = 1 << TABLE_BITS };
 		enum { MANT_BITS = 23 };
-		enum { FRAC_BITS = MANT_BITS - TABLE_BITS };
+		enum { FRAC_BITS = (int)MANT_BITS - (int)TABLE_BITS };
 		enum { FRAC_MASK = (1u << FRAC_BITS) - 1u };
 
 		extern bool g_initialized;


### PR DESCRIPTION
Avoids build failures when running under CP932 (Japanese).

These were a bitch to find. They look just like hyphens in Visual Studio. They had code 0x96.