### PR TITLE
Fix gcc15 -Wtype-limits warnings.

### DIFF
--- a/encoder/basisu_astc_ldr_common.cpp
+++ b/encoder/basisu_astc_ldr_common.cpp
@@ -878,7 +878,7 @@ namespace astc_ldr
 	}
 #endif
 
-	// TODO: Try two-step Lanczos iteration/Rayleigh–Ritz approximation in a 2-dimensional Krylov subspace method vs. power method.
+	// TODO: Try two-step Lanczos iteration/Rayleigh-Ritz approximation in a 2-dimensional Krylov subspace method vs. power method.
 	static vec4F calc_pca_4D(uint32_t num_pixels, const vec4F* pPixels, const vec4F& mean_f)
 	{
 		float m00 = 0, m01 = 0, m02 = 0, m03 = 0;
@@ -1127,7 +1127,7 @@ namespace astc_ldr
 	{
 		BASISU_NOTE_UNUSED(weight_ise_index);
 
-		assert((ccs_index >= 0) && (ccs_index <= 3));
+		assert(ccs_index <= 3);
 		assert((total_weights <= 32) || (total_weights == 65));
 
 		uint64_t total_err = 0;
@@ -4414,7 +4414,7 @@ namespace astc_ldr
 		const cem_encode_params& enc_params, uint32_t flags)
 	{
 		assert(g_initialized);
-		assert((ccs_index >= 0) && (ccs_index <= 3));
+		assert(ccs_index <= 3);
 		assert((ps.m_num_pixels) && (ps.m_num_pixels <= ASTC_LDR_MAX_BLOCK_PIXELS));
 		assert(pWeights0 && pWeights1);
 
@@ -4830,7 +4830,7 @@ namespace astc_ldr
 		uint32_t endpoint_ise_range, uint32_t weight_ise_range,
 		vec4F& low_endpoint, vec4F& high_endpoint, float* pWeights0, float *pWeights1, uint32_t flags)
 	{
-		assert((ccs_index >= 0) && (ccs_index <= 3));
+		assert(ccs_index <= 3);
 		const uint32_t num_endpoint_levels = astc_helpers::get_ise_levels(endpoint_ise_range);
 
 		// astc_helpers::BISE_64_LEVELS=raw weights ([0,64], NOT [0,63])

--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -1,4 +1,4 @@
-﻿// basisu_transcoder.cpp
+// basisu_transcoder.cpp
 // Copyright (C) 2019-2026 Binomial LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -32148,11 +32148,9 @@ namespace bc7f
 			{
 				scaledLow[i] = (xMinColor[i] << (8 - total_bits));
 				scaledLow[i] |= (scaledLow[i] >> total_bits);
-				assert(scaledLow[i] <= 255);
 
 				scaledHigh[i] = (xMaxColor[i] << (8 - total_bits));
 				scaledHigh[i] |= (scaledHigh[i] >> total_bits);
-				assert(scaledHigh[i] <= 255);
 			}
 
 			float err0 = 0, err1 = 0;
@@ -32222,11 +32220,9 @@ namespace bc7f
 			{
 				scaledLow[i] = (xMinColor[i] << (8 - total_bits));
 				scaledLow[i] |= (scaledLow[i] >> total_bits);
-				assert(scaledLow[i] <= 255);
 
 				scaledHigh[i] = (xMaxColor[i] << (8 - total_bits));
 				scaledHigh[i] |= (scaledHigh[i] >> total_bits);
-				assert(scaledHigh[i] <= 255);
 			}
 
 			float err = 0;


### PR DESCRIPTION
Only appeared in Debug config as the code was asserts.

In  encoder/basisu_astc_ldr_common.cpp removed a clause that was always true. In transcoder/basisu_transcoder.cpp removed asserts that were always true because of the data type being compared.