### PR TITLE
Shared library support for C API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 # VS project and working files
 *.vcxproj.user
 .vs/
+.vscode/
 Debug/
 Release/
 x64/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ if (BASISU_BUILD_WASM)
     set(BASISU_SAN OFF CACHE BOOL "" FORCE)
 endif()
 
+message("Initial BUILD_SHARED_LIBS=${BUILD_SHARED_LIBSf}")
 message("Initial CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 message("Initial BASISU_BUILD_X64=${BASISU_BUILD_X64}")
 message("Initial BASISU_BUILD_WASM=${BASISU_BUILD_WASM}")
@@ -305,14 +306,30 @@ if (BASISU_ZSTD)
     set(ENCODER_LIB_SRC_LIST ${ENCODER_LIB_SRC_LIST} zstd/zstd.c)
 endif()
 
-# Create the static library
-add_library(basisu_encoder STATIC ${ENCODER_LIB_SRC_LIST})
+# Create the library
+add_library(basisu_encoder ${ENCODER_LIB_SRC_LIST})
 
-# Create the basisu executable and link against the static library
+include(GenerateExportHeader)
+generate_export_header(basisu_encoder)
+
+if (BUILD_SHARED_LIBS)
+    set_target_properties(basisu_encoder PROPERTIES
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN 1
+        # Empty string sets values to cmake default
+        RUNTIME_OUTPUT_DIRECTORY ""  # .dll
+        ARCHIVE_OUTPUT_DIRECTORY ""  # .lib (import lib)
+        LIBRARY_OUTPUT_DIRECTORY ""  # .so on Linux
+    )
+else ()
+    target_compile_definitions(basisu_encoder PUBLIC BASISU_STATIC)
+endif ()
+
+# Create the basisu executable and link against the library
 add_executable(basisu basisu_tool.cpp)
 target_link_libraries(basisu PRIVATE basisu_encoder)
 
-# Create the new example executable and link against the static library
+# Create the new example executable and link against the library
 if(BASISU_EXAMPLES)
     add_executable(example example/example.cpp)
     target_link_libraries(example PRIVATE basisu_encoder)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,9 @@ if (BASISU_BUILD_WASM)
 
     # WASM cannot use sanitizers
     set(BASISU_SAN OFF CACHE BOOL "" FORCE)
+    
+    # WASM cannot link as a shared object
+    set(BASISU_SHARED OFF CACHE BOOL "" FORCE)
 endif()
 
 message("Initial CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,11 @@ if (BASISU_BUILD_WASM)
     set(BASISU_SHARED OFF CACHE BOOL "" FORCE)
 endif()
 
+if (BASISU_BUILD_PYTHON)
+    # Dynamic linking is not supported on Python builds
+    set(BASISU_SHARED OFF CACHE BOOL "" FORCE)
+endif()
+
 message("Initial CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 message("Initial BASISU_SHARED=${BASISU_SHARED}")
 message("Initial BASISU_BUILD_X64=${BASISU_BUILD_X64}")
@@ -278,8 +283,6 @@ set(ENCODER_LIB_SRC_LIST
     encoder/basisu_uastc_hdr_4x4_enc.h
     encoder/basisu_astc_ldr_common.h
     encoder/basisu_astc_ldr_encode.h
-    encoder/basisu_wasm_api.cpp
-    encoder/basisu_wasm_transcoder_api.cpp
     encoder/cppspmd_flow.h
     encoder/cppspmd_math_declares.h
     encoder/cppspmd_math.h
@@ -315,13 +318,18 @@ endif()
 # Create the library
 
 if (BASISU_SHARED)
-    add_library(basisu_encoder SHARED ${ENCODER_LIB_SRC_LIST})
+    add_library(basisu_encoder SHARED ${ENCODER_LIB_SRC_LIST}
+        encoder/basisu_wasm_api.cpp
+        encoder/basisu_wasm_transcoder_api.cpp
+    )
+
     set_target_properties(basisu_encoder PROPERTIES
         CXX_VISIBILITY_PRESET hidden
         VISIBILITY_INLINES_HIDDEN 1
         VERSION   2.10
         SOVERSION 2
-        )
+    )
+
     if (MSVC)
         set_target_properties(basisu_encoder PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY_DEBUG          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
@@ -330,6 +338,7 @@ if (BASISU_SHARED)
             RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL     ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
     endif()
+    
     target_compile_definitions(basisu_encoder PUBLIC BASISU_SHARED)
 else()
     add_library(basisu_encoder STATIC ${ENCODER_LIB_SRC_LIST})
@@ -619,7 +628,6 @@ if (BASISU_BUILD_WASM)
     endif()
 
     add_executable(${BASISU_TRANSCODER_WASM_OUTPUT_NAME} 
-        ${CMAKE_CURRENT_SOURCE_DIR}/encoder/basisu_wasm_transcoder_api.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/transcoder/basisu_transcoder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/zstd/zstddeclib.c)
             
@@ -682,7 +690,7 @@ if (BASISU_BUILD_PYTHON AND NOT BASISU_BUILD_WASM)
 
     pybind11_add_module(basisu_transcoder_python
         python/basisu_transcoder_pybind11.cpp
-        encoder/basisu_wasm_transcoder_api.cpp  
+        encoder/basisu_wasm_transcoder_api.cpp
         transcoder/basisu_transcoder.cpp
         zstd/zstddeclib.c
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(BASISU_STATIC "static linking" FALSE)
+option(BASISU_STATIC "Link runtime libraries statically" FALSE)
+option(BASISU_SHARED "Build basis-universal as a shared library" FALSE)
 option(BASISU_SAN "sanitize" FALSE)
 option(BASISU_EXAMPLES "build examples" TRUE)
 option(BASISU_WASM_THREADING "Enable WASI threading support" OFF)
@@ -86,8 +87,8 @@ if (BASISU_BUILD_WASM)
     set(BASISU_SAN OFF CACHE BOOL "" FORCE)
 endif()
 
-message("Initial BUILD_SHARED_LIBS=${BUILD_SHARED_LIBSf}")
 message("Initial CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+message("Initial BASISU_SHARED=${BASISU_SHARED}")
 message("Initial BASISU_BUILD_X64=${BASISU_BUILD_X64}")
 message("Initial BASISU_BUILD_WASM=${BASISU_BUILD_WASM}")
 message("Initial BASISU_WASM_THREADING=${BASISU_WASM_THREADING}")
@@ -312,17 +313,11 @@ add_library(basisu_encoder ${ENCODER_LIB_SRC_LIST})
 include(GenerateExportHeader)
 generate_export_header(basisu_encoder)
 
-if (BUILD_SHARED_LIBS)
+if (BASISU_SHARED)
     set_target_properties(basisu_encoder PROPERTIES
         CXX_VISIBILITY_PRESET hidden
-        VISIBILITY_INLINES_HIDDEN 1
-        # Empty string sets values to cmake default
-        RUNTIME_OUTPUT_DIRECTORY ""  # .dll
-        ARCHIVE_OUTPUT_DIRECTORY ""  # .lib (import lib)
-        LIBRARY_OUTPUT_DIRECTORY ""  # .so on Linux
-    )
-else ()
-    target_compile_definitions(basisu_encoder PUBLIC BASISU_STATIC)
+        VISIBILITY_INLINES_HIDDEN 1)
+    target_compile_definitions(basisu_encoder PUBLIC BASISU_SHARED)
 endif ()
 
 # Create the basisu executable and link against the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,9 +310,6 @@ endif()
 # Create the library
 add_library(basisu_encoder ${ENCODER_LIB_SRC_LIST})
 
-include(GenerateExportHeader)
-generate_export_header(basisu_encoder)
-
 if (BASISU_SHARED)
     set_target_properties(basisu_encoder PROPERTIES
         CXX_VISIBILITY_PRESET hidden

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,7 +379,7 @@ if (BASISU_BUILD_WASM)
         
     endif()
 
-    # 256 MB initial, 3.5 GB max � safe defaults for BasisU
+    # 256 MB initial, 3.5 GB max  safe defaults for BasisU
     target_link_options(basisu PRIVATE
         -Wl,--initial-memory=268435456
         -Wl,--max-memory=3758096384

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,14 +308,16 @@ if (BASISU_ZSTD)
 endif()
 
 # Create the library
-add_library(basisu_encoder ${ENCODER_LIB_SRC_LIST})
 
 if (BASISU_SHARED)
+    add_library(basisu_encoder SHARED ${ENCODER_LIB_SRC_LIST})
     set_target_properties(basisu_encoder PROPERTIES
         CXX_VISIBILITY_PRESET hidden
         VISIBILITY_INLINES_HIDDEN 1)
     target_compile_definitions(basisu_encoder PUBLIC BASISU_SHARED)
-endif ()
+else()
+    add_library(basisu_encoder STATIC ${ENCODER_LIB_SRC_LIST})
+endif()
 
 # Create the basisu executable and link against the library
 add_executable(basisu basisu_tool.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,8 @@ set(ENCODER_LIB_SRC_LIST
     encoder/basisu_uastc_hdr_4x4_enc.h
     encoder/basisu_astc_ldr_common.h
     encoder/basisu_astc_ldr_encode.h
+    encoder/basisu_wasm_api.cpp
+    encoder/basisu_wasm_transcoder_api.cpp
     encoder/cppspmd_flow.h
     encoder/cppspmd_math_declares.h
     encoder/cppspmd_math.h
@@ -313,7 +315,18 @@ if (BASISU_SHARED)
     add_library(basisu_encoder SHARED ${ENCODER_LIB_SRC_LIST})
     set_target_properties(basisu_encoder PROPERTIES
         CXX_VISIBILITY_PRESET hidden
-        VISIBILITY_INLINES_HIDDEN 1)
+        VISIBILITY_INLINES_HIDDEN 1
+        VERSION   2.10
+        SOVERSION 2
+        )
+    if (MSVC)
+        set_target_properties(basisu_encoder PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY_DEBUG          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            RUNTIME_OUTPUT_DIRECTORY_RELEASE        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL     ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        )
+    endif()
     target_compile_definitions(basisu_encoder PUBLIC BASISU_SHARED)
 else()
     add_library(basisu_encoder STATIC ${ENCODER_LIB_SRC_LIST})
@@ -328,7 +341,7 @@ if(BASISU_EXAMPLES)
     add_executable(example example/example.cpp)
     target_link_libraries(example PRIVATE basisu_encoder)
     
-    add_executable(example_capi example_capi/example_capi.c encoder/basisu_wasm_api.cpp encoder/basisu_wasm_transcoder_api.cpp)
+    add_executable(example_capi example_capi/example_capi.c)
     target_link_libraries(example_capi PRIVATE basisu_encoder)
     
     add_executable(example_transcoding example_transcoding/example_transcoding.cpp example_transcoding/utils.cpp zstd/zstddeclib.c transcoder/basisu_transcoder.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,8 @@ set(ENCODER_LIB_SRC_LIST
     encoder/basisu_astc_ldr_common.cpp
     encoder/basisu_astc_ldr_encode.cpp
     encoder/basisu_tinyexr.cpp
+    encoder/basisu_wasm_api.cpp
+    encoder/basisu_wasm_transcoder_api.cpp
     transcoder/basisu_transcoder.cpp
     encoder/basisu_astc_hdr_6x6_enc.h
     encoder/basisu_astc_hdr_common.h
@@ -318,10 +320,7 @@ endif()
 # Create the library
 
 if (BASISU_SHARED)
-    add_library(basisu_encoder SHARED ${ENCODER_LIB_SRC_LIST}
-        encoder/basisu_wasm_api.cpp
-        encoder/basisu_wasm_transcoder_api.cpp
-    )
+    add_library(basisu_encoder SHARED ${ENCODER_LIB_SRC_LIST})
 
     set_target_properties(basisu_encoder PROPERTIES
         CXX_VISIBILITY_PRESET hidden

--- a/encoder/basisu_wasm_api_common.h
+++ b/encoder/basisu_wasm_api_common.h
@@ -1,6 +1,7 @@
 // File: basisu_wasm_api_common.h
 #pragma once
 #include "stdint.h"
+#include "../transcoder/basisu_config.h"
 
 #if defined(__wasm__)
 	#if defined(__cplusplus)
@@ -9,9 +10,9 @@
 		#define BU_WASM_EXPORT(name) __attribute__((export_name(name)))
 	#endif
 #elif defined(__cplusplus)
-	#define BU_WASM_EXPORT(name) extern "C"
+	#define BU_WASM_EXPORT(name) BASISU_API extern "C"
 #else
-	#define BU_WASM_EXPORT(name)
+	#define BU_WASM_EXPORT(name) BASISU_API
 #endif
 
 // wasm_bool_t is an alias for uint32_t

--- a/encoder/basisu_wasm_api_common.h
+++ b/encoder/basisu_wasm_api_common.h
@@ -10,7 +10,7 @@
 		#define BU_WASM_EXPORT(name) __attribute__((export_name(name)))
 	#endif
 #elif defined(__cplusplus)
-	#define BU_WASM_EXPORT(name) BASISU_API extern "C"
+	#define BU_WASM_EXPORT(name) extern "C" BASISU_API
 #else
 	#define BU_WASM_EXPORT(name) BASISU_API
 #endif

--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -61,6 +61,23 @@
 #define strcasecmp _stricmp
 #endif
 
+// Export macro for shared libraries
+#ifdef BASISU_STATIC
+    #define BASISU_API
+#elif defined(_WIN32)
+    #ifdef basisu_encoder_EXPORTS
+        #define BASISU_API __declspec(dllexport)
+    #else
+        #define BASISU_API __declspec(dllimport)
+    #endif
+#else
+    #ifdef basisu_encoder_EXPORTS
+        #define BASISU_API __attribute__((visibility("default")))
+    #else
+        #define BASISU_API
+    #endif
+#endif
+
 // Set to one to enable debug printf()'s when any errors occur, for development/debugging. Especially useful for WebGL development.
 #ifndef BASISU_FORCE_DEVEL_MESSAGES
 // Do not check in as 1!

--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -62,7 +62,7 @@
 #endif
 
 // Export macro for shared libraries
-#ifdef BASISU_STATIC
+#ifndef BASISU_SHARED
     #define BASISU_API
 #elif defined(_WIN32)
     #ifdef basisu_encoder_EXPORTS

--- a/transcoder/basisu.h
+++ b/transcoder/basisu.h
@@ -61,23 +61,6 @@
 #define strcasecmp _stricmp
 #endif
 
-// Export macro for shared libraries
-#ifndef BASISU_SHARED
-    #define BASISU_API
-#elif defined(_WIN32)
-    #ifdef basisu_encoder_EXPORTS
-        #define BASISU_API __declspec(dllexport)
-    #else
-        #define BASISU_API __declspec(dllimport)
-    #endif
-#else
-    #ifdef basisu_encoder_EXPORTS
-        #define BASISU_API __attribute__((visibility("default")))
-    #else
-        #define BASISU_API
-    #endif
-#endif
-
 // Set to one to enable debug printf()'s when any errors occur, for development/debugging. Especially useful for WebGL development.
 #ifndef BASISU_FORCE_DEVEL_MESSAGES
 // Do not check in as 1!

--- a/transcoder/basisu_config.h
+++ b/transcoder/basisu_config.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifndef BASISU_SHARED
+    #define BASISU_API
+#elif defined(_WIN32)
+    #ifdef basisu_encoder_EXPORTS
+        #define BASISU_API __declspec(dllexport)
+    #else
+        #define BASISU_API __declspec(dllimport)
+    #endif
+#else
+    #ifdef basisu_encoder_EXPORTS
+        #define BASISU_API __attribute__((visibility("default")))
+    #else
+        #define BASISU_API
+    #endif
+#endif


### PR DESCRIPTION
This PR adds support for compiling basis universal as a shared object (.dll or .so). Only the C API (basisu_wasm_api.h and basis_wasm_transcoder_api.h) has been exposed. 

Main changes:
- CMake option `BASISU_SHARED` has been added to control compiling as a shared library.
- The above option is disabled on wasm builds, as shared libraries aren't a thing there.
- `BASISU_API` macro for exporting symbols, in new `basisu_config.h` file.

Currently, compiling the tool or example executables with this feature enabled fails since they require access to the full basisu API which is not exported (maybe we can disable compiling those targets or add a cmake warning when attempting this). It works perfectly for the C API example.