### PR TITLE
Fixed build for Universal Windows Platfrom ARM (32-bit)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,13 @@ if (MSVC)
             RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )   
     endif()
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+        # Disable deprecation of unsafe `fopen` that tinyexr.h uses.
+        # Otherwise MSVC will emit warnings (error C4996) that break the UWP build.
+        target_compile_definitions(basisu_encoder PRIVATE _CRT_SECURE_NO_WARNINGS)
+    endif()
+
 endif()
 
 # ------------------------------------------------------------

--- a/transcoder/basisu_transcoder.cpp
+++ b/transcoder/basisu_transcoder.cpp
@@ -23583,7 +23583,7 @@ namespace basist
 		{
 #if defined(__EMSCRIPTEN__) || defined(__clang__) || defined(__GNUC__)
 			return __builtin_popcount(x);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64))
 			return __popcnt(x);
 #else
 			int count = 0;
@@ -29766,7 +29766,7 @@ namespace bc7f
 	{
 #if defined(__EMSCRIPTEN__) || defined(__clang__) || defined(__GNUC__)
 		return __builtin_popcount(x);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64))
 		return __popcnt(x);
 #else
 		int count = 0;
@@ -34019,10 +34019,19 @@ namespace bc7f
 		
 	static inline int pop16(uint32_t x)
 	{
-#if defined(_MSC_VER)
+#if defined(__EMSCRIPTEN__) || defined(__clang__) || defined(__GNUC__)
+		return __builtin_popcount(x & 0xFFFFu);
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64))
 		return __popcnt16((unsigned short)x);
 #else
-		return __builtin_popcount(x & 0xFFFFu);
+		uint32_t y = x & 0xFFFFu;
+		int count = 0;
+		while (y) 
+		{
+			y &= (y - 1);
+			++count;
+		}
+		return count;
 #endif
 	}
 


### PR DESCRIPTION
Hi,

I maintain KTX for Unity (which uses BasisU indirectly via KTX-Software) and Unity 6.0 will support UWP ARM (e.g. Hololens 1) well into 2027.

Contains two distinct fixes:

- fix: Addressed missing `__popcnt16` when building with MSC++ for UWP ARM (32-bit).
- fix: Disable deprecation of unsafe `fopen` on MSVC/UWP only to silence compiler error in `tinyexr.h`.

I created a tiny [GitHub action](https://github.com/atteneder/basis_universal/blob/c8092b625fada757993b5d1944f23ff824a31d22/.github/workflows/uwp-arm.yml) that [ran the affected build successfully](https://github.com/atteneder/basis_universal/actions/runs/25946006188). I didn't include it in this PR, seeing that you seem to be running your CI elsewhere.

Thanks for having a look!